### PR TITLE
R0.1.1

### DIFF
--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -103,7 +103,7 @@ module top(
     reg [11:0] l1_vscroll_r,                  l1_vscroll_next;
 
     reg  [1:0] video_output_mode_r,           video_output_mode_next;
-    reg        line_mode_r,                   line_mode_next;
+    reg        line_interlace_mode_r,         line_interlace_mode_next;
 
     reg  [7:0] audio_pcm_sample_rate_r,       audio_pcm_sample_rate_next;
     reg        audio_mode_stereo_r,           audio_mode_stereo_next;
@@ -148,7 +148,7 @@ module top(
 
         5'h09: begin
             if (dc_select_r == 0) begin
-                rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, line_mode_r, chroma_disable_r, video_output_mode_r};
+                rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, line_interlace_mode_r, chroma_disable_r, video_output_mode_r};
             end else begin
                 rddata = dc_active_hstart_r[9:2];
             end
@@ -299,7 +299,7 @@ module top(
         l0_enabled_next                  = l0_enabled_r;
         l1_enabled_next                  = l1_enabled_r;
         chroma_disable_next              = chroma_disable_r;
-        line_mode_next                   = line_mode_r;
+        line_interlace_mode_next         = line_interlace_mode_r;
         dc_hscale_next                   = dc_hscale_r;
         dc_vscale_next                   = dc_vscale_r;
         dc_border_color_next             = dc_border_color_r;
@@ -425,12 +425,12 @@ module top(
 
                 5'h09: begin
                     if (dc_select_r == 0) begin
-                        sprites_enabled_next   = write_data[6];
-                        l1_enabled_next        = write_data[5];
-                        l0_enabled_next        = write_data[4];
-                        line_mode_next         = write_data[3];
-                        chroma_disable_next    = write_data[2];
-                        video_output_mode_next = write_data[1:0];
+                        sprites_enabled_next     = write_data[6];
+                        l1_enabled_next          = write_data[5];
+                        l0_enabled_next          = write_data[4];
+                        line_interlace_mode_next = write_data[3];
+                        chroma_disable_next      = write_data[2];
+                        video_output_mode_next   = write_data[1:0];
                     end else begin
                         dc_active_hstart_next[9:2] = write_data;
                         dc_active_hstart_next[1:0] = 0;
@@ -589,7 +589,7 @@ module top(
             l0_enabled_r                  <= 0;
             l1_enabled_r                  <= 0;
             chroma_disable_r              <= 0;
-            line_mode_r                   <= 0;
+            line_interlace_mode_r         <= 1;
             dc_hscale_r                   <= 8'd128;
             dc_vscale_r                   <= 8'd128;
             dc_border_color_r             <= 0;
@@ -666,7 +666,7 @@ module top(
             l0_enabled_r                  <= l0_enabled_next;
             l1_enabled_r                  <= l1_enabled_next;
             chroma_disable_r              <= chroma_disable_next;
-            line_mode_r                   <= line_mode_next;
+            line_interlace_mode_r         <= line_interlace_mode_next;
             dc_hscale_r                   <= dc_hscale_next;
             dc_vscale_r                   <= dc_vscale_next;
             dc_border_color_r             <= dc_border_color_next;
@@ -1081,7 +1081,7 @@ module top(
 
         // Line buffer / palette interface
         .palette_rgb_data(palette_rgb_data[11:0]),
-        .line_mode(line_mode_r),
+        .interlace(line_interlace_mode_r),
 
         .next_frame(video_composite_next_frame),
         .next_line(video_composite_next_line),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -103,6 +103,7 @@ module top(
     reg [11:0] l1_vscroll_r,                  l1_vscroll_next;
 
     reg  [1:0] video_output_mode_r,           video_output_mode_next;
+    reg        line_mode_r,                   line_mode_next;
 
     reg  [7:0] audio_pcm_sample_rate_r,       audio_pcm_sample_rate_next;
     reg        audio_mode_stereo_r,           audio_mode_stereo_next;
@@ -147,7 +148,7 @@ module top(
 
         5'h09: begin
             if (dc_select_r == 0) begin
-                rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, 1'b0, chroma_disable_r, video_output_mode_r};
+                rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, line_mode_r, chroma_disable_r, video_output_mode_r};
             end else begin
                 rddata = dc_active_hstart_r[9:2];
             end
@@ -298,6 +299,7 @@ module top(
         l0_enabled_next                  = l0_enabled_r;
         l1_enabled_next                  = l1_enabled_r;
         chroma_disable_next              = chroma_disable_r;
+        line_mode_next                   = line_mode_r;
         dc_hscale_next                   = dc_hscale_r;
         dc_vscale_next                   = dc_vscale_r;
         dc_border_color_next             = dc_border_color_r;
@@ -426,6 +428,7 @@ module top(
                         sprites_enabled_next   = write_data[6];
                         l1_enabled_next        = write_data[5];
                         l0_enabled_next        = write_data[4];
+                        line_mode_next         = write_data[3];
                         chroma_disable_next    = write_data[2];
                         video_output_mode_next = write_data[1:0];
                     end else begin
@@ -586,6 +589,7 @@ module top(
             l0_enabled_r                  <= 0;
             l1_enabled_r                  <= 0;
             chroma_disable_r              <= 0;
+            line_mode_r                   <= 0;
             dc_hscale_r                   <= 8'd128;
             dc_vscale_r                   <= 8'd128;
             dc_border_color_r             <= 0;
@@ -662,6 +666,7 @@ module top(
             l0_enabled_r                  <= l0_enabled_next;
             l1_enabled_r                  <= l1_enabled_next;
             chroma_disable_r              <= chroma_disable_next;
+            line_mode_r                   <= line_mode_next;
             dc_hscale_r                   <= dc_hscale_next;
             dc_vscale_r                   <= dc_vscale_next;
             dc_border_color_r             <= dc_border_color_next;
@@ -1076,6 +1081,7 @@ module top(
 
         // Line buffer / palette interface
         .palette_rgb_data(palette_rgb_data[11:0]),
+        .line_mode(line_mode_r),
 
         .next_frame(video_composite_next_frame),
         .next_line(video_composite_next_line),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -1073,6 +1073,8 @@ module top(
     wire [5:0] video_composite_luma, video_composite_chroma;
     wire [3:0] video_rgb_r, video_rgb_g, video_rgb_b;
     wire       video_rgb_sync_n;
+    wire       video_rgb_hsync;
+    wire       video_rgb_vsync;
     wire [5:0] video_composite_chroma2 = chroma_disable_r ? 6'd0 : video_composite_chroma;
 
     video_composite video_composite(
@@ -1097,7 +1099,9 @@ module top(
         .rgb_r(video_rgb_r),
         .rgb_g(video_rgb_g),
         .rgb_b(video_rgb_b),
-        .rgb_sync_n(video_rgb_sync_n));
+        .rgb_sync_n(video_rgb_sync_n),
+        .rgb_hsync(video_rgb_hsync),
+        .rgb_vsync(video_rgb_vsync));
 
     //////////////////////////////////////////////////////////////////////////
     // VGA video
@@ -1158,8 +1162,13 @@ module top(
             vga_r     <= video_rgb_r;
             vga_g     <= video_rgb_g;
             vga_b     <= video_rgb_b;
-            vga_hsync <= video_rgb_sync_n;
-            vga_vsync <= 0;
+            if (chroma_disable_r) begin
+                vga_hsync <= video_rgb_hsync;
+                vga_vsync <= video_rgb_vsync;
+            end else begin
+                vga_hsync <= video_rgb_sync_n;
+                vga_vsync <= 1'b0;
+            end
         end
 
         default: begin

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -447,7 +447,7 @@ module top(
                 5'h0A: begin
                     if (dc_select_r == 0) begin
                         dc_hscale_next            = write_data;
-                    end else begin
+                    end else if (dc_select_r == 1) begin
                         dc_active_hstop_next[9:2] = write_data;
                         dc_active_hstop_next[1:0] = 0;
                     end
@@ -455,7 +455,7 @@ module top(
                 5'h0B: begin
                     if (dc_select_r == 0) begin
                         dc_vscale_next             = write_data;
-                    end else begin
+                    end else if (dc_select_r == 1) begin
                         dc_active_vstart_next[8:1] = write_data;
                         dc_active_vstart_next[0]   = 0;
                     end
@@ -463,7 +463,7 @@ module top(
                 5'h0C: begin
                     if (dc_select_r == 0) begin
                         dc_border_color_next      = write_data;
-                    end else begin
+                    end else if (dc_select_r == 1) begin
                         dc_active_vstop_next[8:1] = write_data;
                         dc_active_vstop_next[0]   = 0;
                     end

--- a/fpga/source/video/video_composite.v
+++ b/fpga/source/video/video_composite.v
@@ -7,7 +7,7 @@ module video_composite(
     // Line buffer / palette interface
     input  wire [11:0] palette_rgb_data,
 
-    input wire line_mode,
+    input wire interlace,
 
     output wire        next_frame,
     output wire        next_line,
@@ -85,6 +85,8 @@ module video_composite(
     // uses the same composite sync signalling as 480i so 263 line mode is used
     // here.
 
+
+    wire line_mode = interlace;
 
     reg [10:0] vcnt = 0;  // half-lines
     wire v_sync =

--- a/fpga/source/video/video_composite.v
+++ b/fpga/source/video/video_composite.v
@@ -7,6 +7,8 @@ module video_composite(
     // Line buffer / palette interface
     input  wire [11:0] palette_rgb_data,
 
+    input wire line_mode,
+
     output wire        next_frame,
     output wire        next_line,
     output wire        next_pixel,
@@ -62,39 +64,48 @@ module video_composite(
     // Vertical video timing (NTSC 60Hz):
     //
     // field1 (even):
-    //      0-5 equalization
-    //     6-11 vsync
-    //    12-17 equalization
-    //    18-37 blank active
-    //   38-524 active     (243,5 lines)
+    //       480i                         |       240p (263 line mode)
+    // -----------------------------------+----------------------------------
+    //      0-5 equalization              |       0-5 equalization
+    //     6-11 vsync                     |      6-11 vsync
+    //    12-17 equalization              |     12-17 equalization
+    //    18-37 blank active              |     18-37 blank active
+    //   38-524 active     (243,5 lines)  |    38-525 active     (244 lines)
     //
     // field2 (odd):
-    //  525-530 equalization
-    //  531-536 vsync
-    //  537-542 equalization
-    //  543-562 blank active
-    // 563-1049 active     (243,5 lines)
+    //       480i                         |       240p (263 line mode)
+    // -----------------------------------+----------------------------------
+    //  525-530 equalization              |   526-531 equalization
+    //  531-536 vsync                     |   532-537 vsync
+    //  537-542 equalization              |   538-543 equalization
+    //  543-562 blank active              |   544-563 blank active
+    // 563-1049 active     (243,5 lines)  |  564-1051 active     (244 lines)
+    //
+    // Most 240p implementations use the 262 line mode, however the 263 line mode
+    // uses the same composite sync signalling as 480i so 263 line mode is used
+    // here.
+
 
     reg [10:0] vcnt = 0;  // half-lines
     wire v_sync =
         (vcnt >=   6 && vcnt <=  11) ||
-        (vcnt >= 531 && vcnt <= 536);
+        (vcnt >= (531+line_mode) && vcnt <= (536+line_mode));
 
     wire v_equalization =
         (vcnt >=   0 && vcnt <=   5) ||
         (vcnt >=  12 && vcnt <=  17) ||
-        (vcnt >= 525 && vcnt <= 530) ||
-        (vcnt >= 537 && vcnt <= 542);
+        (vcnt >= (525+line_mode) && vcnt <= (530+line_mode)) ||
+        (vcnt >= (537+line_mode) && vcnt <= (542+line_mode));
 
     wire v_active =
-        (vcnt >=   38+4 && vcnt <=  524-3) ||   // 240 lines
-        (vcnt >=  563+5 && vcnt <= 1049-2);     // 240 lines
+        (vcnt >=   38+4 && vcnt <=  (524+line_mode)-3) ||   // 240 lines
+        (vcnt >=  563+5 && vcnt <= (1049+line_mode)-2);     // 240 lines
 
     reg field; // 0: even, 1: odd
 
     wire v_last2           = (vcnt == 38+3 || vcnt == 563+4);
-    wire v_last            = (vcnt == 1049);
-    wire v_even_field_last = (vcnt == 524);
+    wire v_last            = (vcnt == (1049+{8'b0,line_mode,1'b0}));
+    wire v_even_field_last = (vcnt == (524+line_mode));
 
     assign next_line     = (hcnt == H_SYNC + H_BACK_PORCH - 1);
 
@@ -118,7 +129,7 @@ module video_composite(
     assign current_field = current_field_r;
 
 
-    assign vblank_pulse  = h_half_line_last && (vcnt == 524 || vcnt == 1049);
+    assign vblank_pulse  = h_half_line_last && (vcnt == (524+line_mode) || vcnt == (1049+{8'b0,line_mode,1'b0}));
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin

--- a/fpga/source/video/video_composite.v
+++ b/fpga/source/video/video_composite.v
@@ -23,15 +23,17 @@ module video_composite(
     output wire  [3:0] rgb_r,
     output wire  [3:0] rgb_g,
     output wire  [3:0] rgb_b,
-    output wire        rgb_sync_n);
+    output wire        rgb_sync_n,
+    output wire        rgb_hsync,
+    output wire        rgb_vsync);
 
     //
     // Video timing (NTSC 60Hz)
     //
     parameter H_SYNC            = 118;
-    parameter H_BACK_PORCH      = 152;
+    parameter H_BACK_PORCH      = 152 - (152-118);
     parameter H_ACTIVE          = 1280;
-    parameter H_FRONT_PORCH     = 38;
+    parameter H_FRONT_PORCH     = 38 + (152-118);
     parameter H_TOTAL           = H_SYNC + H_BACK_PORCH + H_ACTIVE + H_FRONT_PORCH;
 
     parameter H_HALF                   = H_TOTAL / 2;
@@ -102,6 +104,10 @@ module video_composite(
     wire v_active =
         (vcnt >=   38+4 && vcnt <=  (524+line_mode)-3) ||   // 240 lines
         (vcnt >=  563+5 && vcnt <= (1049+line_mode)-2);     // 240 lines
+
+    wire v_burst_active =
+        (vcnt >=   38+4-20 && vcnt <=  (524+line_mode)-3) ||   // 240 lines
+        (vcnt >=  563+5-20 && vcnt <= (1049+line_mode)-2);     // 240 lines
 
     reg field; // 0: even, 1: odd
 
@@ -184,7 +190,7 @@ module video_composite(
         .r(r),
         .g(g),
         .b(b),
-        .color_burst(v_active && h_color_burst),
+        .color_burst(v_burst_active && h_color_burst),
         .active(v_active && h_active),
         .sync_n_in(mod_sync_n),
 
@@ -195,5 +201,7 @@ module video_composite(
     assign rgb_g = g;
     assign rgb_b = b;
     assign rgb_sync_n = mod_sync_n;
+    assign rgb_hsync = !h_hsync_pulse;
+    assign rgb_vsync = !v_sync;
 
 endmodule

--- a/fpga/vera_module.rdf
+++ b/fpga/vera_module.rdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<RadiantProject version="4.1" title="vera_module" device="iCE40UP5K-SG48I" performance_grade="High-Performance_1.2V" default_implementation="impl">
+<RadiantProject version="4.2" title="vera_module" device="iCE40UP5K-SG48I" performance_grade="High-Performance_1.2V" default_implementation="impl">
     <Options/>
     <Implementation title="impl" dir="impl" description="impl" synthesis="lse" default_strategy="Strategy1">
         <Options def_top="top" top="top"/>
@@ -78,7 +78,7 @@
         <Source name="source/vera_module.pdc" type="Physical Constraints File" type_short="PDC">
             <Options/>
         </Source>
-        <Source name="source/vera_module.sdc" type="Synplify Design Constraints File" type_short="SDC">
+        <Source name="source/vera_module.sdc" type="Synplify Design Constraints File" type_short="FDC">
             <Options/>
         </Source>
     </Implementation>

--- a/fpga/vera_module1.sty
+++ b/fpga/vera_module1.sty
@@ -34,7 +34,7 @@
     <Property name="PROP_BIT_NVCMSecurity" value="False" time="0"/>
     <Property name="PROP_BIT_NoHeader" value="False" time="0"/>
     <Property name="PROP_BIT_NoPullup" value="False" time="0"/>
-    <Property name="PROP_BIT_OSCFREQ" value="Fast" time="0"/>
+    <Property name="PROP_BIT_OSCFREQ" value="Slow" time="0"/>
     <Property name="PROP_BIT_OutFormatBitGen" value="bin" time="0"/>
     <Property name="PROP_BIT_OutFormatBitGen_REF" value="" time="0"/>
     <Property name="PROP_BIT_OutFormatPromGen" value="Intel Hex 32-bit" time="0"/>
@@ -68,6 +68,7 @@
     <Property name="PROP_LST_FSMEncodeStyle" value="Auto" time="0"/>
     <Property name="PROP_LST_ForceGSRInfer" value="Auto" time="0"/>
     <Property name="PROP_LST_IOInsertion" value="True" time="0"/>
+    <Property name="PROP_LST_IgnoreSDCError" value="False" time="0"/>
     <Property name="PROP_LST_InterFileDump" value="False" time="0"/>
     <Property name="PROP_LST_LoopLimit" value="1950" time="0"/>
     <Property name="PROP_LST_MaxFanout" value="1000" time="0"/>
@@ -105,6 +106,7 @@
     <Property name="PROP_MAPSTA_WordCasePaths" value="1" time="0"/>
     <Property name="PROP_MAP_GuideFileMapDes" value="" time="0"/>
     <Property name="PROP_MAP_IgnorePreErr" value="True" time="0"/>
+    <Property name="PROP_MAP_IgnoreSDCErr" value="False" time="0"/>
     <Property name="PROP_MAP_MAPIORegister" value="Auto" time="0"/>
     <Property name="PROP_MAP_MAPInferGSR" value="True" time="0"/>
     <Property name="PROP_MAP_MapModArgs" value="" time="0"/>
@@ -165,6 +167,7 @@
     <Property name="PROP_PAR_StopZero" value="False" time="0"/>
     <Property name="PROP_PAR_parHold" value="On" time="0"/>
     <Property name="PROP_PAR_parPathBased" value="On" time="0"/>
+    <Property name="PROP_POSTSYN_CmdLineArgs" value="" time="0"/>
     <Property name="PROP_POSTSYN_ExtModuleFiles" value="" time="0"/>
     <Property name="PROP_PRE_CmdLineArgs" value="" time="0"/>
     <Property name="PROP_PRE_EdfArrayBoundsCase" value="False" time="0"/>
@@ -205,6 +208,7 @@
     <Property name="PROP_SYNSTA_UnconstrainedPathsNumber" value="10" time="0"/>
     <Property name="PROP_SYN_ClockConversion" value="False" time="0"/>
     <Property name="PROP_SYN_CmdLineArgs" value="" time="0"/>
+    <Property name="PROP_SYN_DisableRegisterRep" value="False" time="0"/>
     <Property name="PROP_SYN_EdfAllowDUPMod" value="False" time="0"/>
     <Property name="PROP_SYN_EdfArea" value="False" time="0"/>
     <Property name="PROP_SYN_EdfArrangeVHDLFiles" value="True" time="0"/>
@@ -224,7 +228,9 @@
     <Property name="PROP_SYN_EdfVerilogInput" value="Verilog 2001" time="0"/>
     <Property name="PROP_SYN_ExportSetting" value="Yes" time="0"/>
     <Property name="PROP_SYN_LibPath" value="" time="0"/>
+    <Property name="PROP_SYN_RamRWCheck" value="False" time="0"/>
     <Property name="PROP_SYN_ResolvedMixedDrivers" value="False" time="0"/>
+    <Property name="PROP_SYN_ResynthesizeAll" value="True" time="0"/>
     <Property name="PROP_SYN_UpdateCompilePtTimData" value="False" time="0"/>
     <Property name="PROP_SYN_UseLPF" value="True" time="0"/>
     <Property name="PROP_SYN_VHDL2008" value="False" time="0"/>


### PR DESCRIPTION
This PR contains the following changes:
* Enable 240P video modes
* Widen DCSEL register space from 2 banks to 64.
* Place VERA version number in upper unused DCSEL banks

This PR began as changes to enable 240P video modes, but also added the DCSEL register space widening to enable VERA revision ID which will be important as bug fixes are introduced in order to allow us to determine if a bug report is against the latest bitstream or not.

240P makes the CRT retro experience both more tolerable (having no interlace flicker) and more "authentic" (looking like an 80s computer display).