### PR TITLE
FX: Separate address and data logic into module

### DIFF
--- a/fpga/source/video/video_modulator.v
+++ b/fpga/source/video/video_modulator.v
@@ -13,31 +13,31 @@ module video_modulator(
     output reg   [5:0] luma,
     output reg   [5:0] chroma);
 
-    parameter Y_R = 27; // 38; //  0.299
-    parameter Y_G = 53; // 75; //  0.587
-    parameter Y_B = 10; // 14; //  0.114
+    parameter Y_R   = 27; // 38; //  0.299
+    parameter Y_G   = 53; // 75; //  0.587
+    parameter Y_B   = 10; // 14; //  0.114
 
-    parameter I_R = 76; //  0.5959
-    parameter I_G = 35; // -0.2746 (this should actually be -35, so *after* multiplication the result is negated)
-    parameter I_B = 41; // -0.3213 (this should actually be -41, so *after* multiplication the result is negated)
+    parameter I_R   = 76; //  0.5959
+    parameter I_G_n = 35; // -0.2746 (this should actually be -35, so *after* multiplication the result is negated)
+    parameter I_B_n = 41; // -0.3213 (this should actually be -41, so *after* multiplication the result is negated)
 
-    parameter Q_R = 27; //  0.2115
-    parameter Q_G = 66; // -0.5227 (this should actually be -66, so *after* multiplication the result is negated)
-    parameter Q_B = 40; //  0.3112
+    parameter Q_R   = 27; //  0.2115
+    parameter Q_G_n = 66; // -0.5227 (this should actually be -66, so *after* multiplication the result is negated)
+    parameter Q_B   = 40; //  0.3112
 
     // We set up two DSPs for 4 of the 9 multiplications
 
-    wire [15:0] Y_G_times_g_16, I_G_times_g_16;
+    wire [15:0] Y_G_times_g_16, I_G_n_times_g_16;
     wire [15:0] Y_R_times_r_16, I_R_times_r_16;
     
     // We use one DSP for two 8x8 unsigned multiplications
     video_modulator_mult_u8xu8_pair video_modulator_mult_ig_yg (
         .clk(clk),
         
-        // I_G_times_g = I_G * g
-        .input_1a_8(I_G[7:0]),
+        // I_G_n_times_g = I_G_n * g
+        .input_1a_8(I_G_n[7:0]),
         .input_1b_8({4'b0000, g}),
-        .output_1_16(I_G_times_g_16),
+        .output_1_16(I_G_n_times_g_16),
         
         // Y_G_times_g = Y_G * g
         .input_2a_8(Y_G[7:0]),
@@ -71,17 +71,17 @@ module video_modulator(
     
     // We put together all the 9 multiplication results (all unsigned so far)
 
-    wire [11:0] Y_R_times_r = Y_R_times_r_16[11:0];   // Y_R_times_r = Y_R * r
-    wire [11:0] Y_G_times_g = Y_G_times_g_16[11:0];   // Y_G_times_g = Y_G * g
-    wire [11:0] Y_B_times_b = b_times_8 + b_times_2;  // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
+    wire [11:0] Y_R_times_r   = Y_R_times_r_16[11:0];     // Y_R_times_r = Y_R * r
+    wire [11:0] Y_G_times_g   = Y_G_times_g_16[11:0];     // Y_G_times_g = Y_G * g
+    wire [11:0] Y_B_times_b   = b_times_8 + b_times_2;    // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
     
-    wire [11:0] Q_R_times_r = Y_R_times_r;            // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
-    wire [11:0] Q_G_times_g = g_times_64 + g_times_2; // Q_G_times_g = Q_G * g and since Q_G is 66 (64+2), Q_G_times_g = 64*g + 2*g
-    wire [11:0] Q_B_times_b = b_times_32 + b_times_8; // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
+    wire [11:0] Q_R_times_r   = Y_R_times_r;              // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
+    wire [11:0] Q_G_n_times_g = g_times_64 + g_times_2;   // Q_G_n_times_g = Q_G_n * g and since Q_G_n is 66 (64+2), Q_G_n_times_g = 64*g + 2*g
+    wire [11:0] Q_B_times_b   = b_times_32 + b_times_8;   // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
 
-    wire [11:0] I_R_times_r = I_R_times_r_16[11:0];   // I_R_times_r = I_R * r
-    wire [11:0] I_G_times_g = I_G_times_g_16[11:0];   // I_G_times_g = I_G * g
-    wire [11:0] I_B_times_b = Q_B_times_b + b;        // I_B_times_b = I_B * b and since I_B is 41 (32+8+1), I_B_times_b = Q_B_times_b + 1*b
+    wire [11:0] I_R_times_r   = I_R_times_r_16[11:0];     // I_R_times_r = I_R * r
+    wire [11:0] I_G_n_times_g = I_G_n_times_g_16[11:0];   // I_G_n_times_g = I_G * g
+    wire [11:0] I_B_n_times_b = Q_B_times_b + b;          // I_B_n_times_b = I_B_n * b and since I_B_n is 41 (32+8+1), I_B_n_times_b = Q_B_times_b + 1*b
     
     reg signed [11:0] y_s;
     reg signed [11:0] i_s;
@@ -97,18 +97,18 @@ module video_modulator(
             end
             2'b01: begin
                 y_s <= (sync_n_in == 0) ? 12'd0 : 12'd544;
-                i_s <= (I_R * 5'd9) - (I_G * 5'd9) - (I_B * 5'd0);
-                q_s <= (Q_R * 5'd9) - (Q_G * 5'd9) + (Q_B * 5'd0);
+                i_s <= (I_R * 5'd9) - (I_G_n * 5'd9) - (I_B_n * 5'd0);
+                q_s <= (Q_R * 5'd9) - (Q_G_n * 5'd9) + (Q_B * 5'd0);
             end
             2'b10: begin
-                y_s <= Y_R_times_r + Y_G_times_g + Y_B_times_b + (128 + 512);
-                i_s <= I_R_times_r - I_G_times_g - I_B_times_b;                 // Effectively negating I_G and I_B here
-                q_s <= Q_R_times_r - Q_G_times_g + Q_B_times_b;                 // Effectively negating Q_G here
+                y_s <= Y_R_times_r + Y_G_times_g   + Y_B_times_b + (128 + 512);
+                i_s <= I_R_times_r - I_G_n_times_g - I_B_n_times_b;               // Effectively negating I_G_n and I_B_n here
+                q_s <= Q_R_times_r - Q_G_n_times_g + Q_B_times_b;                 // Effectively negating Q_G_n here
             end
             2'b11: begin
-                y_s <= (Y_R * 5'd9) + (Y_G * 5'd9) + (Y_B * 5'd0) + (128 + 512);
-                i_s <= (I_R * 5'd9) - (I_G * 5'd9) - (I_B * 5'd0);
-                q_s <= (Q_R * 5'd9) - (Q_G * 5'd9) + (Q_B * 5'd0);
+                y_s <= (Y_R * 5'd9) + (Y_G   * 5'd9) + (Y_B * 5'd0) + (128 + 512);
+                i_s <= (I_R * 5'd9) - (I_G_n * 5'd9) - (I_B_n * 5'd0);
+                q_s <= (Q_R * 5'd9) - (Q_G_n * 5'd9) + (Q_B * 5'd0);
             end
         endcase
         


### PR DESCRIPTION
This change separates the address and data related logic into a "addr_data"-module.

Essentially this a cut-and-paste change, so everything that was removed from top.v should be in addr_data.v now. The only thing that was added was the module and some wires. The naming inside top.v has not been changed to make reviewing a bit easier. This changes nothing to the functionality of VERA. It is meant as preparation for the upcoming changes.

Note: its probably easiest to compare addr_data.v with the old top.v as well.

