### PR TITLE
FX extendable structure for address logic

### DIFF
--- a/fpga/source/addr_data.v
+++ b/fpga/source/addr_data.v
@@ -25,8 +25,14 @@ module addr_data(
     output wire [16:0] ib_addr,
     output wire  [7:0] ib_wrdata,
     output wire        ib_write,
-    output wire        ib_do_access
+    output wire        ib_do_access,
+
+    output wire  [1:0] fx_addr1_mode
     );
+
+    //////////////////////////////////////////////////////////////////////////
+    // Bus accessible registers
+    //////////////////////////////////////////////////////////////////////////
 
     reg [16:0] vram_addr_0_r,                 vram_addr_0_next;
     reg [16:0] vram_addr_1_r,                 vram_addr_1_next;
@@ -36,39 +42,6 @@ module addr_data(
     reg        vram_addr_decr_1_r,            vram_addr_decr_1_next;
     reg  [7:0] vram_data0_r,                  vram_data0_next;
     reg  [7:0] vram_data1_r,                  vram_data1_next;
-
-    // Decode increment value
-    wire [3:0] incr_regval = (access_addr == 5'h03) ? vram_addr_incr_0_r : vram_addr_incr_1_r;
-    reg [9:0] increment;
-    always @* case (incr_regval)
-        4'h0: increment = 'd0;
-        4'h1: increment = 'd1;
-        4'h2: increment = 'd2;
-        4'h3: increment = 'd4;
-        4'h4: increment = 'd8;
-        4'h5: increment = 'd16;
-        4'h6: increment = 'd32;
-        4'h7: increment = 'd64;
-        4'h8: increment = 'd128;
-        4'h9: increment = 'd256;
-        4'hA: increment = 'd512;
-        4'hB: increment = 'd40;
-        4'hC: increment = 'd80;
-        4'hD: increment = 'd160;
-        4'hE: increment = 'd320;
-        4'hF: increment = 'd640;
-    endcase
-
-    reg [16:0] ib_addr_r,      ib_addr_next;
-    reg  [7:0] ib_wrdata_r,    ib_wrdata_next;
-    reg        ib_write_r,     ib_write_next;
-    reg        ib_do_access_r, ib_do_access_next;
-
-    reg        save_result_r;
-    reg        save_result_port_r;
-
-    reg        fetch_ahead_r,  fetch_ahead_next;
-    reg        fetch_ahead_port_r,  fetch_ahead_port_next;
     
     assign vram_addr_0 = vram_addr_0_r;
     assign vram_addr_1 = vram_addr_1_r;
@@ -79,21 +52,136 @@ module addr_data(
     assign vram_data0 = vram_data0_r;
     assign vram_data1 = vram_data1_r;
 
+    reg  [16:0] ib_addr_r,                   ib_addr_next;
+    reg   [7:0] ib_wrdata_r,                 ib_wrdata_next;
+    reg         ib_write_r,                  ib_write_next;
+    reg         ib_do_access_r,              ib_do_access_next;
+
     assign ib_addr = ib_addr_r;
     assign ib_wrdata = ib_wrdata_r;
     assign ib_write = ib_write_r;
     assign ib_do_access = ib_do_access_r;
     
+    parameter
+        MODE_NORMAL      = 2'b00,
+        MODE_LINE_DRAW   = 2'b01,
+        
+        ADDR0_UNTOUCHED  = 2'b00,
+        ADDR0_SET        = 2'b01,
+        ADDR0_INCR_0     = 2'b10,
+        
+        ADDR1_UNTOUCHED  = 3'b000,
+        ADDR1_INCR_1     = 3'b001,
+        ADDR1_SET        = 3'b111;
 
-    wire [16:0] vram_addr             = (access_addr == 5'h03) ? vram_addr_0_r : vram_addr_1_r;
-    wire        vram_addr_decr        = (access_addr == 5'h03) ? vram_addr_decr_0_r : vram_addr_decr_1_r;
-    wire [16:0] vram_addr_incremented = vram_addr + increment;
-    wire [16:0] vram_addr_decremented = vram_addr - increment;
-    wire [16:0] vram_addr_new         = vram_addr_decr ? vram_addr_decremented : vram_addr_incremented;
 
+    reg  [1:0] fx_addr1_mode_r,               fx_addr1_mode_next;
+
+    assign fx_addr1_mode = fx_addr1_mode_r;
+
+    //////////////////////////////////////////////////////////////////////////
+    // Address incrementers
+    //////////////////////////////////////////////////////////////////////////
+    
+    reg signed [10:0] incr_decr_0;
+    always @* case ({vram_addr_decr_0_r, vram_addr_incr_0_r})
+        5'h00: incr_decr_0 = 11'd0;
+        5'h01: incr_decr_0 = 11'd1;
+        5'h02: incr_decr_0 = 11'd2;
+        5'h03: incr_decr_0 = 11'd4;
+        5'h04: incr_decr_0 = 11'd8;
+        5'h05: incr_decr_0 = 11'd16;
+        5'h06: incr_decr_0 = 11'd32;
+        5'h07: incr_decr_0 = 11'd64;
+        5'h08: incr_decr_0 = 11'd128;
+        5'h09: incr_decr_0 = 11'd256;
+        5'h0A: incr_decr_0 = 11'd512;
+        5'h0B: incr_decr_0 = 11'd40;
+        5'h0C: incr_decr_0 = 11'd80;
+        5'h0D: incr_decr_0 = 11'd160;
+        5'h0E: incr_decr_0 = 11'd320;
+        5'h0F: incr_decr_0 = 11'd640;
+        5'h10: incr_decr_0 = -11'd0;
+        5'h11: incr_decr_0 = -11'd1;
+        5'h12: incr_decr_0 = -11'd2;
+        5'h13: incr_decr_0 = -11'd4;
+        5'h14: incr_decr_0 = -11'd8;
+        5'h15: incr_decr_0 = -11'd16;
+        5'h16: incr_decr_0 = -11'd32;
+        5'h17: incr_decr_0 = -11'd64;
+        5'h18: incr_decr_0 = -11'd128;
+        5'h19: incr_decr_0 = -11'd256;
+        5'h1A: incr_decr_0 = -11'd512;
+        5'h1B: incr_decr_0 = -11'd40;
+        5'h1C: incr_decr_0 = -11'd80;
+        5'h1D: incr_decr_0 = -11'd160;
+        5'h1E: incr_decr_0 = -11'd320;
+        5'h1F: incr_decr_0 = -11'd640;
+    endcase
+
+    reg  signed [10:0] incr_decr_1;
+    always @* case ({vram_addr_decr_1_r, vram_addr_incr_1_r})
+        5'h00: incr_decr_1 = 11'd0;
+        5'h01: incr_decr_1 = 11'd1;
+        5'h02: incr_decr_1 = 11'd2;
+        5'h03: incr_decr_1 = 11'd4;
+        5'h04: incr_decr_1 = 11'd8;
+        5'h05: incr_decr_1 = 11'd16;
+        5'h06: incr_decr_1 = 11'd32;
+        5'h07: incr_decr_1 = 11'd64;
+        5'h08: incr_decr_1 = 11'd128;
+        5'h09: incr_decr_1 = 11'd256;
+        5'h0A: incr_decr_1 = 11'd512;
+        5'h0B: incr_decr_1 = 11'd40;
+        5'h0C: incr_decr_1 = 11'd80;
+        5'h0D: incr_decr_1 = 11'd160;
+        5'h0E: incr_decr_1 = 11'd320;
+        5'h0F: incr_decr_1 = 11'd640;
+        5'h10: incr_decr_1 = -11'd0;
+        5'h11: incr_decr_1 = -11'd1;
+        5'h12: incr_decr_1 = -11'd2;
+        5'h13: incr_decr_1 = -11'd4;
+        5'h14: incr_decr_1 = -11'd8;
+        5'h15: incr_decr_1 = -11'd16;
+        5'h16: incr_decr_1 = -11'd32;
+        5'h17: incr_decr_1 = -11'd64;
+        5'h18: incr_decr_1 = -11'd128;
+        5'h19: incr_decr_1 = -11'd256;
+        5'h1A: incr_decr_1 = -11'd512;
+        5'h1B: incr_decr_1 = -11'd40;
+        5'h1C: incr_decr_1 = -11'd80;
+        5'h1D: incr_decr_1 = -11'd160;
+        5'h1E: incr_decr_1 = -11'd320;
+        5'h1F: incr_decr_1 = -11'd640;
+    endcase
+
+    // Note: we are sign extending here, since it might be a negative number
+    wire [16:0] vram_addr_0_incr_decr_0  = vram_addr_0_r + { {6{incr_decr_0[10]}}, incr_decr_0};
+    wire [16:0] vram_addr_1_incr_decr_1  = vram_addr_1_r + { {6{incr_decr_1[10]}}, incr_decr_1};
+
+    //////////////////////////////////////////////////////////////////////////
+    // Internal registers
+    //////////////////////////////////////////////////////////////////////////
+
+    reg         save_result_r;
+    reg         save_result_port_r;
+
+    reg         fetch_ahead_r,  fetch_ahead_next;
+    reg         fetch_ahead_port_r,  fetch_ahead_port_next;
+    
+    reg  [16:0] vram_addr_0_untouched_or_set;
+    reg         vram_addr_0_untouched_or_set_bit16;
+    reg   [7:0] vram_addr_0_untouched_or_set_high, vram_addr_0_untouched_or_set_low;
+        
+    reg  [16:0] vram_addr_1_untouched_or_set;
+    reg         vram_addr_1_untouched_or_set_bit16;
+    reg   [7:0] vram_addr_1_untouched_or_set_high, vram_addr_1_untouched_or_set_low;
+    
+    reg  [1:0]  fx_vram_addr_0_needs_to_be_changed;
+    reg  [2:0]  fx_vram_addr_1_needs_to_be_changed;
     always @* begin
-        vram_addr_0_next                 = vram_addr_0_r;
-        vram_addr_1_next                 = vram_addr_1_r;
+        // vram_addr_0_next                 = vram_addr_0_r;
+        // vram_addr_1_next                 = vram_addr_1_r;
         vram_addr_incr_0_next            = vram_addr_incr_0_r;
         vram_addr_incr_1_next            = vram_addr_incr_1_r;
         vram_addr_decr_0_next            = vram_addr_decr_0_r;
@@ -101,6 +189,11 @@ module addr_data(
         vram_data0_next                  = vram_data0_r;
         vram_data1_next                  = vram_data1_r;
         
+        fx_addr1_mode_next               = fx_addr1_mode_r;
+
+        fx_vram_addr_0_needs_to_be_changed  = 0;
+        fx_vram_addr_1_needs_to_be_changed  = 0;
+
         ib_addr_next                     = ib_addr_r;
         ib_wrdata_next                   = ib_wrdata_r;
         ib_write_next                    = ib_write_r;
@@ -109,66 +202,140 @@ module addr_data(
         fetch_ahead_port_next            = fetch_ahead_port_r;
         fetch_ahead_next                 = 0;
 
-        if (save_result_r) begin
-            if (!save_result_port_r) begin
-                vram_data0_next = vram_rddata;
-            end else begin
-                vram_data1_next = vram_rddata;
-            end
+        //////////////////////////////////////////////////////////////////////////
+        // Save the result coming from VRAM reads
+        //////////////////////////////////////////////////////////////////////////
+
+        if (save_result_r && !save_result_port_r) begin
+            vram_data0_next = vram_rddata;
+        end
+        if (save_result_r && save_result_port_r) begin
+            vram_data1_next = vram_rddata;
+        end
+
+        //////////////////////////////////////////////////////////////////////////
+        // Writes to addresses 00, 01 and 02 (ADDRx_L, ADDRx_M, ADDRx_H)
+        //////////////////////////////////////////////////////////////////////////
+
+        if (do_write && access_addr == 5'h00 && vram_addr_select) begin
+            vram_addr_1_untouched_or_set_low = write_data;
+        end else begin
+            vram_addr_1_untouched_or_set_low = vram_addr_1_r[7:0];
+        end
+        if (do_write && access_addr == 5'h00 && !vram_addr_select) begin
+            vram_addr_0_untouched_or_set_low = write_data;
+        end else begin
+            vram_addr_0_untouched_or_set_low = vram_addr_0_r[7:0];
         end
         
-        if (do_write && access_addr == 5'h00) begin
-            if (vram_addr_select) begin
-                vram_addr_1_next[7:0] = write_data;
-            end else begin
-                vram_addr_0_next[7:0] = write_data;
-            end
-
-            fetch_ahead_port_next = vram_addr_select;
-            fetch_ahead_next = 1;
+        if (do_write && access_addr == 5'h01 && vram_addr_select) begin
+            vram_addr_1_untouched_or_set_high = write_data;
+        end else begin
+            vram_addr_1_untouched_or_set_high = vram_addr_1_r[15:8];
         end
-        if (do_write && access_addr == 5'h01) begin
-            if (vram_addr_select) begin
-                vram_addr_1_next[15:8] = write_data;
-            end else begin
-                vram_addr_0_next[15:8] = write_data;
-            end
-
-            fetch_ahead_port_next = vram_addr_select;
-            fetch_ahead_next = 1;
+        if (do_write && access_addr == 5'h01 && !vram_addr_select) begin
+            vram_addr_0_untouched_or_set_high = write_data;
+        end else begin
+            vram_addr_0_untouched_or_set_high = vram_addr_0_r[15:8];
         end
-        if (do_write && access_addr == 5'h02) begin
-            if (vram_addr_select) begin
-                vram_addr_incr_1_next = write_data[7:4];
-                vram_addr_decr_1_next = write_data[3];
-                vram_addr_1_next[16]  = write_data[0];
-            end else begin
-                vram_addr_incr_0_next = write_data[7:4];
-                vram_addr_decr_0_next = write_data[3];
-                vram_addr_0_next[16]  = write_data[0];
-            end
-
-            fetch_ahead_port_next = vram_addr_select;
-            fetch_ahead_next = 1;
+        
+        if (do_write && access_addr == 5'h02 && vram_addr_select) begin
+            vram_addr_1_untouched_or_set_bit16 = write_data[0];
+            vram_addr_incr_1_next = write_data[7:4];
+            vram_addr_decr_1_next = write_data[3];
+        end else begin
+            vram_addr_1_untouched_or_set_bit16 = vram_addr_1_r[16];
         end
+        if (do_write && access_addr == 5'h02 && !vram_addr_select) begin
+            vram_addr_0_untouched_or_set_bit16 = write_data[0];
+            vram_addr_incr_0_next = write_data[7:4];
+            vram_addr_decr_0_next = write_data[3];
+        end else begin
+            vram_addr_0_untouched_or_set_bit16 = vram_addr_0_r[16];
+        end
+
+        vram_addr_0_untouched_or_set = { vram_addr_0_untouched_or_set_bit16, vram_addr_0_untouched_or_set_high, vram_addr_0_untouched_or_set_low};
+        vram_addr_1_untouched_or_set = { vram_addr_1_untouched_or_set_bit16, vram_addr_1_untouched_or_set_high, vram_addr_1_untouched_or_set_low};
+
+
+        //////////////////////////////////////////////////////////////////////////
+        // ADDR0 control logic and assignment
+        //////////////////////////////////////////////////////////////////////////
+
+        if (do_write && (access_addr == 5'h00 || access_addr == 5'h01 || access_addr == 5'h02) && !vram_addr_select) begin
+            fx_vram_addr_0_needs_to_be_changed = ADDR0_SET;
+        end else if ((do_write || do_read) && access_addr == 5'h03) begin
+            fx_vram_addr_0_needs_to_be_changed = ADDR0_INCR_0;
+        end
+
+        if (fx_vram_addr_0_needs_to_be_changed == ADDR0_INCR_0) begin
+            vram_addr_0_next = vram_addr_0_incr_decr_0;
+        end else begin
+            vram_addr_0_next = vram_addr_0_untouched_or_set;
+        end
+
+        //////////////////////////////////////////////////////////////////////////
+        // Reads from and writes to addresses 03 and 04 (DATA0 and DATA1)
+        //////////////////////////////////////////////////////////////////////////
+
+
         if ((do_write || do_read) && (access_addr == 5'h03 || access_addr == 5'h04)) begin
-            ib_wrdata_next = write_data;
             ib_write_next  = do_write;
-
-            if (do_write) begin
-                ib_addr_next = access_addr == 5'h03 ? vram_addr_0_r : vram_addr_1_r;
-                ib_do_access_next = 1;
-            end
-
-            if (access_addr == 5'h03) begin
-                fetch_ahead_port_next = 0;
-                vram_addr_0_next = vram_addr_new;
-            end else begin
-                fetch_ahead_port_next = 1;
-                vram_addr_1_next = vram_addr_new;
-            end
-            fetch_ahead_next = 1;
         end
+
+        if (do_write && (access_addr == 5'h03 || access_addr == 5'h04)) begin
+            ib_wrdata_next = write_data;
+            ib_addr_next = access_addr == 5'h03 ? vram_addr_0_r : vram_addr_1_r;
+            ib_do_access_next = 1;
+        end
+
+        //////////////////////////////////////////////////////////////////////////
+        // Writes to addresses 09, 0A, 0B and 0C (DCSEL = 2,3,4,5 and 6)
+        //////////////////////////////////////////////////////////////////////////
+        
+        if (do_write && access_addr == 5'h09 && dc_select == 2) begin
+            fx_addr1_mode_next = write_data[1:0];
+        end
+
+        //////////////////////////////////////////////////////////////////////////
+        // ADDR1 control logic and assignment
+        //////////////////////////////////////////////////////////////////////////
+
+        if (do_write && (access_addr == 5'h00 || access_addr == 5'h01 || access_addr == 5'h02) && vram_addr_select) begin
+            fx_vram_addr_1_needs_to_be_changed = ADDR1_SET;
+        end else if ((do_write || do_read) && access_addr == 5'h04 && fx_addr1_mode_r == MODE_NORMAL) begin
+            // in normal addr1-mode we do a "normal" increment
+            fx_vram_addr_1_needs_to_be_changed = ADDR1_INCR_1;  // addr_1 needs to be set with vram_addr_1_incr_decr_1
+        end
+
+        case (fx_vram_addr_1_needs_to_be_changed)
+            ADDR1_INCR_1: begin
+                // We increment addr1 with its own incrementer 
+                vram_addr_1_next = vram_addr_1_incr_decr_1;
+            end
+            default: begin  // ADDR1_UNTOUCHED, ADDR1_SET (and the unused values)
+                // We leave addr1 unchanged, unless just externally/explcitly set
+                vram_addr_1_next = vram_addr_1_untouched_or_set;
+            end
+
+        endcase
+
+        //////////////////////////////////////////////////////////////////////////
+        // Determination of what to fetch ahead
+        //////////////////////////////////////////////////////////////////////////
+
+        if (fx_vram_addr_0_needs_to_be_changed) begin
+            fetch_ahead_port_next = 0;
+            fetch_ahead_next = 1;
+        end else if (fx_vram_addr_1_needs_to_be_changed) begin
+            fetch_ahead_next = 1;
+            fetch_ahead_port_next = 1;
+        end
+          
+        //////////////////////////////////////////////////////////////////////////
+        // Executing the fetch ahead
+        //////////////////////////////////////////////////////////////////////////
+          
         if (fetch_ahead_r) begin
             ib_addr_next      = fetch_ahead_port_r ? vram_addr_1_r : vram_addr_0_r;
             ib_write_next     = 0;
@@ -187,7 +354,9 @@ module addr_data(
             vram_addr_decr_1_r            <= 0;
             vram_data0_r                  <= 0;
             vram_data1_r                  <= 0;
-            
+
+            fx_addr1_mode_r               <= 0;
+
             ib_addr_r                     <= 0;
             ib_wrdata_r                   <= 0;
             ib_do_access_r                <= 0;
@@ -208,6 +377,7 @@ module addr_data(
             vram_data0_r                  <= vram_data0_next;
             vram_data1_r                  <= vram_data1_next;
 
+            fx_addr1_mode_r               <= fx_addr1_mode_next;
             ib_addr_r                     <= ib_addr_next;
             ib_wrdata_r                   <= ib_wrdata_next;
             ib_do_access_r                <= ib_do_access_next;

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -55,6 +55,13 @@ module top(
     wire  [7:0] vram_data0_r;
     wire  [7:0] vram_data1_r;
     
+    wire [16:0] ib_addr_r;
+    wire  [7:0] ib_wrdata_r;
+    wire        ib_write_r;
+    wire        ib_do_access_r;
+    
+    wire  [1:0] fx_addr1_mode;
+
     reg        vram_addr_select_r,            vram_addr_select_next;
     reg  [5:0] dc_select_r,                   dc_select_next;
     reg        fpga_reconfigure_r,            fpga_reconfigure_next;
@@ -151,6 +158,7 @@ module top(
             case(dc_select_r)
                 6'h0: rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, line_interlace_mode_r, chroma_disable_r, video_output_mode_r};
                 6'h1: rddata = dc_active_hstart_r[9:2];
+                6'h2: rddata = {6'b0, fx_addr1_mode};
                 default: rddata = "V";
             endcase
         end
@@ -232,11 +240,6 @@ module top(
     wire [4:0] access_addr = do_write ? wraddr_r : rdaddr_r;
     wire [7:0] write_data  = wrdata_r;
 
-    wire [16:0] ib_addr_r;
-    wire  [7:0] ib_wrdata_r;
-    wire        ib_write_r;
-    wire        ib_do_access_r;
-    
     always @* begin
         vram_addr_select_next            = vram_addr_select_r;
         dc_select_next                   = dc_select_r;
@@ -605,7 +608,9 @@ module top(
         .ib_addr(ib_addr_r),
         .ib_wrdata(ib_wrdata_r),
         .ib_do_access(ib_do_access_r),
-        .ib_write(ib_write_r)
+        .ib_write(ib_write_r),
+
+        .fx_addr1_mode(fx_addr1_mode)
     );
 
     //////////////////////////////////////////////////////////////////////////

--- a/fpga/source/video/video_modulator.v
+++ b/fpga/source/video/video_modulator.v
@@ -25,44 +25,34 @@ module video_modulator(
     parameter Q_G_n = 66; // -0.5227 (this should actually be -66, so *after* multiplication the result is negated)
     parameter Q_B   = 40; //  0.3112
 
-    // We set up two DSPs for 4 of the 9 multiplications
+    // We set up one DSP for 2 of the 9 multiplications
 
-    wire [15:0] Y_G_times_g_16, I_G_n_times_g_16;
-    wire [15:0] Y_R_times_r_16, I_R_times_r_16;
-    
+    wire [15:0] Y_G_times_g_16, Y_R_times_r_16;
+
     // We use one DSP for two 8x8 unsigned multiplications
-    video_modulator_mult_u8xu8_pair video_modulator_mult_ig_yg (
+    video_modulator_mult_u8xu8_pair video_modulator_mult_yg_yr (
         .clk(clk),
-        
-        // I_G_n_times_g = I_G_n * g
-        .input_1a_8(I_G_n[7:0]),
-        .input_1b_8({4'b0000, g}),
-        .output_1_16(I_G_n_times_g_16),
         
         // Y_G_times_g = Y_G * g
         .input_2a_8(Y_G[7:0]),
         .input_2b_8({4'b0000, g}),
-        .output_2_16(Y_G_times_g_16)
-    );
-    
-    // We use another DSP for two 8x8 unsigned multiplications
-    video_modulator_mult_u8xu8_pair video_modulator_mult_yr_ir (
-        .clk(clk),
+        .output_2_16(Y_G_times_g_16),
         
         // Y_R_times_r = Y_R * r
         .input_1a_8(Y_R[7:0]),
         .input_1b_8({4'b0000, r}),
-        .output_1_16(Y_R_times_r_16),
-        
-        // I_R_times_r = I_R * r
-        .input_2a_8(I_R[7:0]),
-        .input_2b_8({4'b0000, r}),
-        .output_2_16(I_R_times_r_16)
+        .output_1_16(Y_R_times_r_16)
     );
+
+
+    // We need these nine differently shifted values to replace the remaining multiplications by additions
     
-    // We need these five differently shifted values to replace the remaining multiplications by additions
+    wire [5:0] r_times_4  = { r, 2'b00 };
+    wire [6:0] r_times_8  = { r, 3'b000 };
+    wire [9:0] r_times_64 = { r, 6'b000000 };
     
     wire [4:0] g_times_2  = { g, 1'b0 };
+    wire [8:0] g_times_32 = { g, 5'b00000 };
     wire [9:0] g_times_64 = { g, 6'b000000 };
 
     wire [4:0] b_times_2  = { b, 1'b0 };
@@ -71,17 +61,17 @@ module video_modulator(
     
     // We put together all the 9 multiplication results (all unsigned so far)
 
-    wire [11:0] Y_R_times_r   = Y_R_times_r_16[11:0];     // Y_R_times_r = Y_R * r
-    wire [11:0] Y_G_times_g   = Y_G_times_g_16[11:0];     // Y_G_times_g = Y_G * g
-    wire [11:0] Y_B_times_b   = b_times_8 + b_times_2;    // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
+    wire [11:0] Y_R_times_r   = Y_R_times_r_16[11:0];       // Y_R_times_r = Y_R * r
+    wire [11:0] Y_G_times_g   = Y_G_times_g_16[11:0];       // Y_G_times_g = Y_G * g
+    wire [11:0] Y_B_times_b   = b_times_8 + b_times_2;      // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
     
-    wire [11:0] Q_R_times_r   = Y_R_times_r;              // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
-    wire [11:0] Q_G_n_times_g = g_times_64 + g_times_2;   // Q_G_n_times_g = Q_G_n * g and since Q_G_n is 66 (64+2), Q_G_n_times_g = 64*g + 2*g
-    wire [11:0] Q_B_times_b   = b_times_32 + b_times_8;   // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
+    wire [11:0] Q_R_times_r   = Y_R_times_r;                // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
+    wire [11:0] Q_G_n_times_g = g_times_64 + g_times_2;     // Q_G_n_times_g = Q_G_n * g and since Q_G_n is 66 (64+2), Q_G_n_times_g = 64*g + 2*g
+    wire [11:0] Q_B_times_b   = b_times_32 + b_times_8;     // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
 
-    wire [11:0] I_R_times_r   = I_R_times_r_16[11:0];     // I_R_times_r = I_R * r
-    wire [11:0] I_G_n_times_g = I_G_n_times_g_16[11:0];   // I_G_n_times_g = I_G * g
-    wire [11:0] I_B_n_times_b = Q_B_times_b + b;          // I_B_n_times_b = I_B_n * b and since I_B_n is 41 (32+8+1), I_B_n_times_b = Q_B_times_b + 1*b
+    wire [11:0] I_R_times_r   = r_times_64 + r_times_8 + r_times_4; // I_R_times_r = I_R * r and since I_R is 76 (64+8+4), I_R_times_r = 64*r + 8*r + 4*2
+    wire [11:0] I_G_n_times_g = g_times_32 + g_times_2 + g; // I_G_n_times_g = I_G * g and since I_G_n is 35 (32+2+1), I_G_n_times_g = 32*g + 2*g + g
+    wire [11:0] I_B_n_times_b = Q_B_times_b + b;            // I_B_n_times_b = I_B_n * b and since I_B_n is 41 (32+8+1), I_B_n_times_b = Q_B_times_b + 1*b
     
     reg signed [11:0] y_s;
     reg signed [11:0] i_s;

--- a/fpga/source/video/video_modulator.v
+++ b/fpga/source/video/video_modulator.v
@@ -13,31 +13,31 @@ module video_modulator(
     output reg   [5:0] luma,
     output reg   [5:0] chroma);
 
-    parameter Y_R = 27; // 38; //  0.299
-    parameter Y_G = 53; // 75; //  0.587
-    parameter Y_B = 10; // 14; //  0.114
+    parameter Y_R   = 27; // 38; //  0.299
+    parameter Y_G   = 53; // 75; //  0.587
+    parameter Y_B   = 10; // 14; //  0.114
 
-    parameter I_R = 76; //  0.5959
-    parameter I_G = 35; // -0.2746 (this should actually be -35, so *after* multiplication the result is negated)
-    parameter I_B = 41; // -0.3213 (this should actually be -41, so *after* multiplication the result is negated)
+    parameter I_R   = 76; //  0.5959
+    parameter I_G_n = 35; // -0.2746 (this should actually be -35, so *after* multiplication the result is negated)
+    parameter I_B_n = 41; // -0.3213 (this should actually be -41, so *after* multiplication the result is negated)
 
-    parameter Q_R = 27; //  0.2115
-    parameter Q_G = 66; // -0.5227 (this should actually be -66, so *after* multiplication the result is negated)
-    parameter Q_B = 40; //  0.3112
+    parameter Q_R   = 27; //  0.2115
+    parameter Q_G_n = 66; // -0.5227 (this should actually be -66, so *after* multiplication the result is negated)
+    parameter Q_B   = 40; //  0.3112
 
     // We set up two DSPs for 4 of the 9 multiplications
 
-    wire [15:0] Y_G_times_g_16, I_G_times_g_16;
+    wire [15:0] Y_G_times_g_16, I_G_n_times_g_16;
     wire [15:0] Y_R_times_r_16, I_R_times_r_16;
     
     // We use one DSP for two 8x8 unsigned multiplications
     video_modulator_mult_u8xu8_pair video_modulator_mult_ig_yg (
         .clk(clk),
         
-        // I_G_times_g = I_G * g
-        .input_1a_8(I_G[7:0]),
+        // I_G_n_times_g = I_G_n * g
+        .input_1a_8(I_G_n[7:0]),
         .input_1b_8({4'b0000, g}),
-        .output_1_16(I_G_times_g_16),
+        .output_1_16(I_G_n_times_g_16),
         
         // Y_G_times_g = Y_G * g
         .input_2a_8(Y_G[7:0]),
@@ -71,17 +71,17 @@ module video_modulator(
     
     // We put together all the 9 multiplication results (all unsigned so far)
 
-    wire [11:0] Y_R_times_r = Y_R_times_r_16[11:0];   // Y_R_times_r = Y_R * r
-    wire [11:0] Y_G_times_g = Y_G_times_g_16[11:0];   // Y_G_times_g = Y_G * g
-    wire [11:0] Y_B_times_b = b_times_8 + b_times_2;  // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
+    wire [11:0] Y_R_times_r   = Y_R_times_r_16[11:0];     // Y_R_times_r = Y_R * r
+    wire [11:0] Y_G_times_g   = Y_G_times_g_16[11:0];     // Y_G_times_g = Y_G * g
+    wire [11:0] Y_B_times_b   = b_times_8 + b_times_2;    // Y_B_times_b = Y_B * b and since Y_B is 10 (8+2), Y_B_times_b = 8*b + 2*b
     
-    wire [11:0] Q_R_times_r = Y_R_times_r;            // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
-    wire [11:0] Q_G_times_g = g_times_64 + g_times_2; // Q_G_times_g = Q_G * g and since Q_G is 66 (64+2), Q_G_times_g = 64*g + 2*g
-    wire [11:0] Q_B_times_b = b_times_32 + b_times_8; // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
+    wire [11:0] Q_R_times_r   = Y_R_times_r;              // Q_R_times_r = Q_R * r and since Q_R is equal to Y_R, Q_R_times_r = Y_R_times_r
+    wire [11:0] Q_G_n_times_g = g_times_64 + g_times_2;   // Q_G_n_times_g = Q_G_n * g and since Q_G_n is 66 (64+2), Q_G_n_times_g = 64*g + 2*g
+    wire [11:0] Q_B_times_b   = b_times_32 + b_times_8;   // Q_B_times_b = Q_B * b and since Q_B is 40 (32+8), Q_B_times_b = 32*b + 8*b
 
-    wire [11:0] I_R_times_r = I_R_times_r_16[11:0];   // I_R_times_r = I_R * r
-    wire [11:0] I_G_times_g = I_G_times_g_16[11:0];   // I_G_times_g = I_G * g
-    wire [11:0] I_B_times_b = Q_B_times_b + b;        // I_B_times_b = I_B * b and since I_B is 41 (32+8+1), I_B_times_b = Q_B_times_b + 1*b
+    wire [11:0] I_R_times_r   = I_R_times_r_16[11:0];     // I_R_times_r = I_R * r
+    wire [11:0] I_G_n_times_g = I_G_n_times_g_16[11:0];   // I_G_n_times_g = I_G * g
+    wire [11:0] I_B_n_times_b = Q_B_times_b + b;          // I_B_n_times_b = I_B_n * b and since I_B_n is 41 (32+8+1), I_B_n_times_b = Q_B_times_b + 1*b
     
     reg signed [11:0] y_s;
     reg signed [11:0] i_s;
@@ -97,18 +97,18 @@ module video_modulator(
             end
             2'b01: begin
                 y_s <= (sync_n_in == 0) ? 12'd0 : 12'd544;
-                i_s <= (I_R * 5'd9) - (I_G * 5'd9) - (I_B * 5'd0);
-                q_s <= (Q_R * 5'd9) - (Q_G * 5'd9) + (Q_B * 5'd0);
+                i_s <= (I_R * 5'd9) - (I_G_n * 5'd9) - (I_B_n * 5'd0);
+                q_s <= (Q_R * 5'd9) - (Q_G_n * 5'd9) + (Q_B * 5'd0);
             end
             2'b10: begin
-                y_s <= Y_R_times_r + Y_G_times_g + Y_B_times_b + (128 + 512);
-                i_s <= I_R_times_r - I_G_times_g - I_B_times_b;                 // Effectively negating I_G and I_B here
-                q_s <= Q_R_times_r - Q_G_times_g + Q_B_times_b;                 // Effectively negating Q_G here
+                y_s <= Y_R_times_r + Y_G_times_g   + Y_B_times_b + (128 + 512);
+                i_s <= I_R_times_r - I_G_n_times_g - I_B_n_times_b;               // Effectively negating I_G_n and I_B_n here
+                q_s <= Q_R_times_r - Q_G_n_times_g + Q_B_times_b;                 // Effectively negating Q_G_n here
             end
             2'b11: begin
-                y_s <= (Y_R * 5'd9) + (Y_G * 5'd9) + (Y_B * 5'd0) + (128 + 512);
-                i_s <= (I_R * 5'd9) - (I_G * 5'd9) - (I_B * 5'd0);
-                q_s <= (Q_R * 5'd9) - (Q_G * 5'd9) + (Q_B * 5'd0);
+                y_s <= (Y_R * 5'd9) + (Y_G   * 5'd9) + (Y_B * 5'd0) + (128 + 512);
+                i_s <= (I_R * 5'd9) - (I_G_n * 5'd9) - (I_B_n * 5'd0);
+                q_s <= (Q_R * 5'd9) - (Q_G_n * 5'd9) + (Q_B * 5'd0);
             end
         endcase
         


### PR DESCRIPTION
This is the last non-functional change to the FX branch.

It changes the structure of the address logic, so it will become extendable. This is needed to add a lot of the functionality of the FX update. Since this change is the last non-functional change, it will essentially become "base camp" after this. Also if this version of VERA is indeed backwards compatible, the changes following this PR can much easier to be proven to be so as well. So checking for equivalence is quite important.

Besides that, another two multipliers (in modulator.v) are replaced by adders. This is needed to (further) reduce timing pressure. The modulator used 4 DSPs before this change, but the DSPs are on the sides/border of the chip. This basicly means the modulator logic has to be "stretched" accross the entire (or at least a large part of the) chip. Reducing it to 3 DSPs helps shorten the paths between the components. This change also frees up 1 DSP, which is not used.

---

Sidenote 1: due to a change in line-ending (in addr_data.v) the diff view in github doesn't show the actual differences. A local diff-tool probably has to be used (or a side-by-side comparison).
Sidenote 2: due to the need for merging back and forth between forks commits of _earlier_ PRs are in this PR. It is there best to concentrate on the actual file differences.