### PR TITLE
Add an ability to replay and loop FIFO data

### DIFF
--- a/fpga/source/audio/audio.v
+++ b/fpga/source/audio/audio.v
@@ -18,6 +18,7 @@ module audio(
     // Audio FIFO interface
     input  wire        fifo_reset,
     input  wire        fifo_restart,
+    input  wire        fifo_loop,
     input  wire  [7:0] fifo_wrdata,
     input  wire        fifo_write,
     output wire        fifo_full,
@@ -72,6 +73,7 @@ module audio(
         // Audio FIFO interface
         .fifo_reset(fifo_reset),
         .fifo_restart(fifo_restart),
+        .fifo_loop(fifo_loop),
         .fifo_wrdata(fifo_wrdata),
         .fifo_write(fifo_write),
         .fifo_full(fifo_full),

--- a/fpga/source/audio/audio.v
+++ b/fpga/source/audio/audio.v
@@ -17,6 +17,7 @@ module audio(
 
     // Audio FIFO interface
     input  wire        fifo_reset,
+    input  wire        fifo_restart,
     input  wire  [7:0] fifo_wrdata,
     input  wire        fifo_write,
     output wire        fifo_full,
@@ -70,6 +71,7 @@ module audio(
 
         // Audio FIFO interface
         .fifo_reset(fifo_reset),
+        .fifo_restart(fifo_restart),
         .fifo_wrdata(fifo_wrdata),
         .fifo_write(fifo_write),
         .fifo_full(fifo_full),

--- a/fpga/source/audio/audio_fifo.v
+++ b/fpga/source/audio/audio_fifo.v
@@ -13,8 +13,7 @@ module audio_fifo(
     
     output wire       empty,
     output wire       almost_empty,
-    output wire       full,
-    input  wire       loop_enable);
+    output wire       full);
 
     reg [11:0] wridx_r = 0;
     reg [11:0] rdidx_r = 0;
@@ -22,8 +21,7 @@ module audio_fifo(
     reg [7:0] mem_r [4095:0];
 
     wire [11:0] wridx_next = wridx_r + 12'd1;
-    wire [11:0] rdidx_inc1 = rdidx_r + 12'd1;
-    wire [11:0] rdidx_next = (loop_enable && (rdidx_inc1 == wridx_r)) ? 12'd0 : rdidx_inc1;
+    wire [11:0] rdidx_next = rdidx_r + 12'd1;
     wire [11:0] fifo_count = wridx_r - rdidx_r;
 
     assign empty        = (wridx_r == rdidx_r);

--- a/fpga/source/audio/audio_fifo.v
+++ b/fpga/source/audio/audio_fifo.v
@@ -9,10 +9,12 @@ module audio_fifo(
 
     output reg  [7:0] rddata,
     input  wire       rd_en,
+    input  wire       rd_rst,
     
     output wire       empty,
     output wire       almost_empty,
-    output wire       full);
+    output wire       full,
+    input  wire       loop_enable);
 
     reg [11:0] wridx_r = 0;
     reg [11:0] rdidx_r = 0;
@@ -20,7 +22,8 @@ module audio_fifo(
     reg [7:0] mem_r [4095:0];
 
     wire [11:0] wridx_next = wridx_r + 12'd1;
-    wire [11:0] rdidx_next = rdidx_r + 12'd1;
+    wire [11:0] rdidx_inc1 = rdidx_r + 12'd1;
+    wire [11:0] rdidx_next = (loop_enable && (rdidx_inc1 == wridx_r)) ? 12'd0 : rdidx_inc1;
     wire [11:0] fifo_count = wridx_r - rdidx_r;
 
     assign empty        = (wridx_r == rdidx_r);
@@ -42,6 +45,10 @@ module audio_fifo(
             if (rd_en && !empty) begin
                 rddata <= mem_r[rdidx_r];
                 rdidx_r <= rdidx_next;
+            end
+
+            if (rd_rst) begin
+                rdidx_r <= 0;
             end
         end
     end

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -110,6 +110,7 @@ module top(
     reg        audio_mode_16bit_r,            audio_mode_16bit_next;
     reg        audio_fifo_reset_r,            audio_fifo_reset_next;
     reg        audio_fifo_restart_r,          audio_fifo_restart_next;
+    reg        audio_fifo_loop_r,             audio_fifo_loop_next;
     wire       audio_fifo_full;
     reg  [3:0] audio_pcm_volume_r,            audio_pcm_volume_next;
     reg  [7:0] audio_fifo_wrdata_r,           audio_fifo_wrdata_next;
@@ -345,6 +346,7 @@ module top(
         audio_mode_16bit_next            = audio_mode_16bit_r;
         audio_fifo_reset_next            = 0;
         audio_fifo_restart_next          = 0;
+        audio_fifo_loop_next             = audio_fifo_loop_r;
         audio_pcm_volume_next            = audio_pcm_volume_r;
         audio_fifo_wrdata_next           = audio_fifo_wrdata_r;
         audio_fifo_write_next            = 0;
@@ -512,8 +514,9 @@ module top(
                 5'h1A: l1_vscroll_next[11:8] = write_data[3:0];
 
                 5'h1B: begin
-                    audio_fifo_reset_next       = write_data[7];
+                    audio_fifo_reset_next       = write_data[7:6] == 2'b10;
                     audio_fifo_restart_next     = write_data[6];
+                    audio_fifo_loop_next        = write_data[7:6] == 2'b11;
                     audio_mode_16bit_next       = write_data[5];
                     audio_mode_stereo_next      = write_data[4];
                     audio_pcm_volume_next       = write_data[3:0];
@@ -636,6 +639,7 @@ module top(
             audio_mode_16bit_r            <= 0;
             audio_fifo_reset_r            <= 0;
             audio_fifo_restart_r          <= 0;
+            audio_fifo_loop_r             <= 0;
             audio_pcm_volume_r            <= 0;
             audio_fifo_wrdata_r           <= 0;
             audio_fifo_write_r            <= 0;
@@ -714,6 +718,7 @@ module top(
             audio_mode_16bit_r            <= audio_mode_16bit_next;
             audio_fifo_reset_r            <= audio_fifo_reset_next;
             audio_fifo_restart_r          <= audio_fifo_restart_next;
+            audio_fifo_loop_r             <= audio_fifo_loop_next;
             audio_pcm_volume_r            <= audio_pcm_volume_next;
             audio_fifo_wrdata_r           <= audio_fifo_wrdata_next;
             audio_fifo_write_r            <= audio_fifo_write_next;
@@ -1248,6 +1253,7 @@ module top(
         // Audio FIFO interface
         .fifo_reset(audio_fifo_reset_r),
         .fifo_restart(audio_fifo_restart_r),
+        .fifo_loop(audio_fifo_loop_r),
         .fifo_wrdata(audio_fifo_wrdata_r),
         .fifo_write(audio_fifo_write_r),
         .fifo_full(audio_fifo_full),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -109,6 +109,7 @@ module top(
     reg        audio_mode_stereo_r,           audio_mode_stereo_next;
     reg        audio_mode_16bit_r,            audio_mode_16bit_next;
     reg        audio_fifo_reset_r,            audio_fifo_reset_next;
+    reg        audio_fifo_restart_r,          audio_fifo_restart_next;
     wire       audio_fifo_full;
     reg  [3:0] audio_pcm_volume_r,            audio_pcm_volume_next;
     reg  [7:0] audio_fifo_wrdata_r,           audio_fifo_wrdata_next;
@@ -343,6 +344,7 @@ module top(
         audio_mode_stereo_next           = audio_mode_stereo_r;
         audio_mode_16bit_next            = audio_mode_16bit_r;
         audio_fifo_reset_next            = 0;
+        audio_fifo_restart_next          = 0;
         audio_pcm_volume_next            = audio_pcm_volume_r;
         audio_fifo_wrdata_next           = audio_fifo_wrdata_r;
         audio_fifo_write_next            = 0;
@@ -511,6 +513,7 @@ module top(
 
                 5'h1B: begin
                     audio_fifo_reset_next       = write_data[7];
+                    audio_fifo_restart_next     = write_data[6];
                     audio_mode_16bit_next       = write_data[5];
                     audio_mode_stereo_next      = write_data[4];
                     audio_pcm_volume_next       = write_data[3:0];
@@ -632,6 +635,7 @@ module top(
             audio_mode_stereo_r           <= 0;
             audio_mode_16bit_r            <= 0;
             audio_fifo_reset_r            <= 0;
+            audio_fifo_restart_r          <= 0;
             audio_pcm_volume_r            <= 0;
             audio_fifo_wrdata_r           <= 0;
             audio_fifo_write_r            <= 0;
@@ -709,6 +713,7 @@ module top(
             audio_mode_stereo_r           <= audio_mode_stereo_next;
             audio_mode_16bit_r            <= audio_mode_16bit_next;
             audio_fifo_reset_r            <= audio_fifo_reset_next;
+            audio_fifo_restart_r          <= audio_fifo_restart_next;
             audio_pcm_volume_r            <= audio_pcm_volume_next;
             audio_fifo_wrdata_r           <= audio_fifo_wrdata_next;
             audio_fifo_write_r            <= audio_fifo_write_next;
@@ -1242,6 +1247,7 @@ module top(
 
         // Audio FIFO interface
         .fifo_reset(audio_fifo_reset_r),
+        .fifo_restart(audio_fifo_restart_r),
         .fifo_wrdata(audio_fifo_wrdata_r),
         .fifo_write(audio_fifo_write_r),
         .fifo_full(audio_fifo_full),


### PR DESCRIPTION
This update adds 2 write bits to VERA registers: AUDIO_CTRL bit 6 and AUDIO_RATE bit 7.

Writing 1 to AUDIO_CTRL bit 6 will only reset FIFO's read position to 0. This allows a sample data in the buffer to be replayed any time without refilling it again. AUDIO_RATE bit 7 set will enable looped playback where the read position is automatically reset to 0 if the buffer becomes empty in the next sample. Although an AUDIO_RATE value of 128 will still play at the maximum rate *without looping*.

Note that a position of 0 here means an internal buffer's address. Which means a FIFO reset (write 1 to AUDIO_CTRL bit 7) is required in order to reset the write position to 0 too before uploading a sample data and make these methods above play correctly.