### PR TITLE
32-bit cache and multiplier/accumulator

### DIFF
--- a/fpga/source/addr_data.v
+++ b/fpga/source/addr_data.v
@@ -23,15 +23,26 @@ module addr_data(
     output wire  [7:0] vram_data1,
 
     output wire [16:0] ib_addr,
+    output wire        ib_cache_write_enabled,
+    output wire        ib_transparency_enabled,
+    output wire        ib_one_byte_cache_cycling,
+    output wire [31:0] ib_mult_accum_cache32,
+    output reg   [7:0] ib_cache8,
     output wire  [7:0] ib_wrdata,
     output wire        ib_write,
     output wire        ib_do_access,
-
+    
+    output wire        fx_transparency_enabled,
+    output wire        fx_cache_write_enabled,
+    output wire        fx_cache_fill_enabled,
+    output wire        fx_one_byte_cache_cycling,
+    output wire        fx_16bit_hop,
     output wire  [1:0] fx_addr1_mode,
     
     output reg   [7:0] fx_fill_length_low,
     output reg   [7:0] fx_fill_length_high
-    );
+    ) /* synthesis syn_hier = "hard" */;
+
 
     //////////////////////////////////////////////////////////////////////////
     // Bus accessible registers
@@ -56,11 +67,18 @@ module addr_data(
     assign vram_data1 = vram_data1_r;
 
     reg  [16:0] ib_addr_r,                   ib_addr_next;
+    reg         ib_cache_write_enabled_r,    ib_cache_write_enabled_next;
+    reg         ib_transparency_enabled_r,   ib_transparency_enabled_next;
+    reg         ib_one_byte_cache_cycling_r, ib_one_byte_cache_cycling_next;
+    reg  [31:0] ib_cache32_r,                ib_cache32_next;
     reg   [7:0] ib_wrdata_r,                 ib_wrdata_next;
     reg         ib_write_r,                  ib_write_next;
     reg         ib_do_access_r,              ib_do_access_next;
 
     assign ib_addr = ib_addr_r;
+    assign ib_transparency_enabled = ib_transparency_enabled_r;
+    assign ib_one_byte_cache_cycling = ib_one_byte_cache_cycling_r;
+    assign ib_cache_write_enabled = ib_cache_write_enabled_r;
     assign ib_wrdata = ib_wrdata_r;
     assign ib_write = ib_write_r;
     assign ib_do_access = ib_do_access_r;
@@ -85,12 +103,21 @@ module addr_data(
 
 
     reg  [1:0] fx_addr1_mode_r,               fx_addr1_mode_next;
+    reg        fx_16bit_hop_r,                fx_16bit_hop_next;
+    reg        fx_mult_enabled_r,             fx_mult_enabled_next;
+    reg        fx_reset_accum_r,              fx_reset_accum_next;
+    reg        fx_accumulate_r,               fx_accumulate_next;
+    reg        fx_add_or_sub_r,               fx_add_or_sub_next;
     
     reg  [5:0] fx_tiledata_base_address_r,    fx_tiledata_base_address_next;
     reg  [5:0] fx_map_base_address_r,         fx_map_base_address_next;
     reg        fx_apply_clip_r,               fx_apply_clip_next;
     
     reg  [1:0] fx_map_size_r,                 fx_map_size_next;
+    reg  [1:0] fx_cache_byte_index_r,         fx_cache_byte_index_next;
+    
+    reg        fx_cache_increment_mode_r,     fx_cache_increment_mode_next;
+    reg        fx_cache_fill_enabled_r,       fx_cache_fill_enabled_next;
     
     // Pixel positions are fixed point numbers with an 11-bit integer part and a 9-bit fractional part (11.9)
     reg [19:0] fx_pixel_pos_x_r,              fx_pixel_pos_x_next;
@@ -105,6 +132,17 @@ module addr_data(
     reg [14:0] fx_pixel_incr_x_r,             fx_pixel_incr_x_next;
     reg [14:0] fx_pixel_incr_y_r,             fx_pixel_incr_y_next;
 
+    reg        fx_cache_write_enabled_r,      fx_cache_write_enabled_next;
+    reg        fx_transparency_enabled_r,     fx_transparency_enabled_next;
+    reg        fx_one_byte_cache_cycling_r,   fx_one_byte_cache_cycling_next;
+    
+    reg  [1:0] fx_16bit_hop_start_index_r,    fx_16bit_hop_start_index_next;
+
+    assign fx_transparency_enabled = fx_transparency_enabled_r;
+    assign fx_cache_write_enabled = fx_cache_write_enabled_r;
+    assign fx_cache_fill_enabled = fx_cache_fill_enabled_r;
+    assign fx_one_byte_cache_cycling = fx_one_byte_cache_cycling_r;
+    assign fx_16bit_hop = fx_16bit_hop_r;
     assign fx_addr1_mode = fx_addr1_mode_r;
 
     //////////////////////////////////////////////////////////////////////////
@@ -148,44 +186,59 @@ module addr_data(
     endcase
 
     reg  signed [10:0] incr_decr_1;
-    always @* case ({vram_addr_decr_1_r, vram_addr_incr_1_r})
-        5'h00: incr_decr_1 = 11'd0;
-        5'h01: incr_decr_1 = 11'd1;
-        5'h02: incr_decr_1 = 11'd2;
-        5'h03: incr_decr_1 = 11'd4;
-        5'h04: incr_decr_1 = 11'd8;
-        5'h05: incr_decr_1 = 11'd16;
-        5'h06: incr_decr_1 = 11'd32;
-        5'h07: incr_decr_1 = 11'd64;
-        5'h08: incr_decr_1 = 11'd128;
-        5'h09: incr_decr_1 = 11'd256;
-        5'h0A: incr_decr_1 = 11'd512;
-        5'h0B: incr_decr_1 = 11'd40;
-        5'h0C: incr_decr_1 = 11'd80;
-        5'h0D: incr_decr_1 = 11'd160;
-        5'h0E: incr_decr_1 = 11'd320;
-        5'h0F: incr_decr_1 = 11'd640;
-        5'h10: incr_decr_1 = -11'd0;
-        5'h11: incr_decr_1 = -11'd1;
-        5'h12: incr_decr_1 = -11'd2;
-        5'h13: incr_decr_1 = -11'd4;
-        5'h14: incr_decr_1 = -11'd8;
-        5'h15: incr_decr_1 = -11'd16;
-        5'h16: incr_decr_1 = -11'd32;
-        5'h17: incr_decr_1 = -11'd64;
-        5'h18: incr_decr_1 = -11'd128;
-        5'h19: incr_decr_1 = -11'd256;
-        5'h1A: incr_decr_1 = -11'd512;
-        5'h1B: incr_decr_1 = -11'd40;
-        5'h1C: incr_decr_1 = -11'd80;
-        5'h1D: incr_decr_1 = -11'd160;
-        5'h1E: incr_decr_1 = -11'd320;
-        5'h1F: incr_decr_1 = -11'd640;
-    endcase
+    wire signed [10:0] incr_1_16bit_hop_4;
+    wire signed [10:0] incr_1_16bit_hop_320;
+    
+    assign incr_1_16bit_hop_4 = (vram_addr_1_r[1:0] == fx_16bit_hop_start_index_r) ? 11'd1 : 11'd3;
+    assign incr_1_16bit_hop_320 = (vram_addr_1_r[1:0] == fx_16bit_hop_start_index_r) ? 11'd1 : 11'd319;
+    always @* begin
+        case ({vram_addr_decr_1_r, vram_addr_incr_1_r})
+            5'h00: incr_decr_1 = 11'd0;
+            5'h01: incr_decr_1 = 11'd1;
+            5'h02: incr_decr_1 = 11'd2;
+            5'h03: incr_decr_1 = 11'd4;
+            5'h04: incr_decr_1 = 11'd8;
+            5'h05: incr_decr_1 = 11'd16;
+            5'h06: incr_decr_1 = 11'd32;
+            5'h07: incr_decr_1 = 11'd64;
+            5'h08: incr_decr_1 = 11'd128;
+            5'h09: incr_decr_1 = 11'd256;
+            5'h0A: incr_decr_1 = 11'd512;
+            5'h0B: incr_decr_1 = 11'd40;
+            5'h0C: incr_decr_1 = 11'd80;
+            5'h0D: incr_decr_1 = 11'd160;
+            5'h0E: incr_decr_1 = 11'd320;
+            5'h0F: incr_decr_1 = 11'd640;
+            5'h10: incr_decr_1 = -11'd0;
+            5'h11: incr_decr_1 = -11'd1;
+            5'h12: incr_decr_1 = -11'd2;
+            5'h13: incr_decr_1 = -11'd4;
+            5'h14: incr_decr_1 = -11'd8;
+            5'h15: incr_decr_1 = -11'd16;
+            5'h16: incr_decr_1 = -11'd32;
+            5'h17: incr_decr_1 = -11'd64;
+            5'h18: incr_decr_1 = -11'd128;
+            5'h19: incr_decr_1 = -11'd256;
+            5'h1A: incr_decr_1 = -11'd512;
+            5'h1B: incr_decr_1 = -11'd40;
+            5'h1C: incr_decr_1 = -11'd80;
+            5'h1D: incr_decr_1 = -11'd160;
+            5'h1E: incr_decr_1 = -11'd320;
+            5'h1F: incr_decr_1 = -11'd640;
+        endcase
+        
+        if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h03) begin
+            incr_decr_1 = fx_16bit_hop_r ? incr_1_16bit_hop_4 : 11'd4;
+        end 
+        if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h0E) begin
+            incr_decr_1 = fx_16bit_hop_r ? incr_1_16bit_hop_320 : 11'd320;
+        end 
+
+    end
 
     // Note: we are sign extending here, since it might be a negative number
-    wire [16:0] vram_addr_0_incr_decr_0  = vram_addr_0_r + { {6{incr_decr_0[10]}}, incr_decr_0};
-    wire [16:0] vram_addr_1_incr_decr_1  = vram_addr_1_r + { {6{incr_decr_1[10]}}, incr_decr_1};
+    wire [16:0] vram_addr_0_incr_decr_0  = vram_addr_0_r + { {6{incr_decr_0[10]}}, incr_decr_0} /* synthesis syn_keep=1 */;
+    wire [16:0] vram_addr_1_incr_decr_1  = vram_addr_1_r + { {6{incr_decr_1[10]}}, incr_decr_1} /* synthesis syn_keep=1 */;
     wire [16:0] vram_addr_1_incr_decr_10 = vram_addr_1_incr_decr_1 + { {6{incr_decr_0[10]}}, incr_decr_0};
 
     //////////////////////////////////////////////////////////////////////////
@@ -211,9 +264,9 @@ module addr_data(
     reg         vram_addr_1_untouched_or_set_bit16;
     reg   [7:0] vram_addr_1_untouched_or_set_high, vram_addr_1_untouched_or_set_low;
     
-    reg  [16:0] vram_addr_1_tileindex_lookup;
-    reg  [16:0] vram_addr_1_tiledata_using_tilemap;
-    reg  [16:0] vram_addr_1_start_of_horizontal_fill_line;
+    reg  [16:0] vram_addr_1_tileindex_lookup /* synthesis syn_keep=1 */;
+    reg  [16:0] vram_addr_1_tiledata_using_tilemap /* synthesis syn_keep=1 */;
+    reg  [16:0] vram_addr_1_start_of_horizontal_fill_line /* synthesis syn_keep=1 */;
     
     reg  [10:0] fx_pixel_position_in_map_x, fx_pixel_position_in_map_y;
     reg   [2:0] fx_pixel_position_in_tile_x, fx_pixel_position_in_tile_y;
@@ -222,9 +275,17 @@ module addr_data(
     reg   [7:0] fx_tile_index_looked_up;
     reg         fx_position_is_outside_map;
     
-    reg  [1:0]  fx_vram_addr_0_needs_to_be_changed;
-    reg  [2:0]  fx_vram_addr_1_needs_to_be_changed;
+    reg   [7:0] fx_byte_to_be_loaded_into_cache;
+    reg  [31:0] fx_cache_filled_with_byte;
+    
+    reg  [1:0]  fx_vram_addr_0_needs_to_be_changed /* synthesis syn_keep=1 */;
+    reg  [2:0]  fx_vram_addr_1_needs_to_be_changed /* synthesis syn_keep=1 */;
     reg         fx_pixel_position_needs_to_be_updated;
+    
+    wire [16:0] vram_addr             = (access_addr == 5'h03) ? vram_addr_0_r : vram_addr_1_r;
+    wire is_audio_address             = (vram_addr[16:6]  == 'b11111100111);
+    wire is_palette_address           = (vram_addr[16:9]  == 'b11111101);
+    wire is_sprite_attr_address       = (vram_addr[16:10] == 'b1111111);
 
     //////////////////////////////////////////////////////////////////////////
     // Calculation for X and Y accumulation
@@ -260,6 +321,21 @@ module addr_data(
 
     end
 
+    //////////////////////////////////////////////////////////////////////////
+    // Cache byte cycling
+    //////////////////////////////////////////////////////////////////////////
+
+    always @* begin
+        case (fx_cache_byte_index_r)
+            2'b00: ib_cache8 = ib_cache32_r[7:0];
+            2'b01: ib_cache8 = ib_cache32_r[15:8];
+            2'b10: ib_cache8 = ib_cache32_r[23:16];
+            2'b11: ib_cache8 = ib_cache32_r[31:24];
+        endcase
+    end
+
+
+
     always @* begin
         // vram_addr_0_next                 = vram_addr_0_r;
         // vram_addr_1_next                 = vram_addr_1_r;
@@ -271,6 +347,11 @@ module addr_data(
         vram_data1_next                  = vram_data1_r;
         
         fx_addr1_mode_next               = fx_addr1_mode_r;
+        fx_16bit_hop_next                = fx_16bit_hop_r;
+        fx_mult_enabled_next             = fx_mult_enabled_r;
+        fx_reset_accum_next              = 0;
+        fx_accumulate_next               = 0;
+        fx_add_or_sub_next               = fx_add_or_sub_r;
         
         fx_tiledata_base_address_next    = fx_tiledata_base_address_r;
         
@@ -278,6 +359,9 @@ module addr_data(
         fx_apply_clip_next               = fx_apply_clip_r;
         
         fx_map_size_next                 = fx_map_size_r;
+        fx_cache_byte_index_next         = fx_cache_byte_index_r;
+        fx_cache_increment_mode_next     = fx_cache_increment_mode_r;
+        fx_cache_fill_enabled_next       = fx_cache_fill_enabled_r;
 
         fx_pixel_pos_x_next              = fx_pixel_pos_x_r;
         fx_pixel_pos_y_next              = fx_pixel_pos_y_r;
@@ -288,16 +372,26 @@ module addr_data(
         fx_pixel_incr_x_next             = fx_pixel_incr_x_r;
         fx_pixel_incr_y_next             = fx_pixel_incr_y_r;
 
+        fx_cache_write_enabled_next      = fx_cache_write_enabled_r;
+        fx_transparency_enabled_next     = fx_transparency_enabled_r;
+        fx_one_byte_cache_cycling_next   = fx_one_byte_cache_cycling_r;
+        
         fx_use_result_as_tileindex_next  = fx_use_result_as_tileindex_r;
         fx_calculate_addr1_based_on_position_next = fx_calculate_addr1_based_on_position_r;
         fx_increment_on_overflow_next    = fx_increment_on_overflow_r;
         fx_calculate_addr1_based_on_tileindex_next = fx_calculate_addr1_based_on_tileindex_r;
+        fx_16bit_hop_start_index_next    = fx_16bit_hop_start_index_r;
 
         fx_vram_addr_0_needs_to_be_changed = 0;
         fx_vram_addr_1_needs_to_be_changed = 0;
         fx_pixel_position_needs_to_be_updated = 0;
 
         ib_addr_next                     = ib_addr_r;
+        ib_transparency_enabled_next     = 0;
+        ib_one_byte_cache_cycling_next   = 0;
+        ib_cache_write_enabled_next      = 0;
+        // ib_cache32_next                  = ib_cache32_r;
+      
         ib_wrdata_next                   = ib_wrdata_r;
         ib_write_next                    = ib_write_r;
         ib_do_access_next                = 0;
@@ -325,6 +419,10 @@ module addr_data(
         //////////////////////////////////////////////////////////////////////////
         // Writes to addresses 00, 01 and 02 (ADDRx_L, ADDRx_M, ADDRx_H)
         //////////////////////////////////////////////////////////////////////////
+
+        if (do_write && access_addr == 5'h00 && vram_addr_select && fx_16bit_hop_r) begin
+            fx_16bit_hop_start_index_next = write_data[1:0];  // We remember the lower two bits of the address that was set to addr1
+        end
 
         if (do_write && access_addr == 5'h00 && vram_addr_select) begin
             vram_addr_1_untouched_or_set_low = write_data;
@@ -417,14 +515,58 @@ module addr_data(
         end
 
 
+        fx_byte_to_be_loaded_into_cache = access_addr == 5'h03 ? vram_data0_r : vram_data1_r;
+        case (fx_cache_byte_index_r)
+            2'b00: fx_cache_filled_with_byte = { ib_cache32_r[31:8],  fx_byte_to_be_loaded_into_cache                    };
+            2'b01: fx_cache_filled_with_byte = { ib_cache32_r[31:16], fx_byte_to_be_loaded_into_cache, ib_cache32_r[7:0] };
+            2'b10: fx_cache_filled_with_byte = { ib_cache32_r[31:24], fx_byte_to_be_loaded_into_cache, ib_cache32_r[15:0] };
+            2'b11: fx_cache_filled_with_byte = {                      fx_byte_to_be_loaded_into_cache, ib_cache32_r[23:0] };
+        endcase
+
+        if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04)) begin
+            // When cache is enabled, the byte that has been read is put into the cache (at the correct position of the 32 bits)
+            ib_cache32_next = fx_cache_filled_with_byte;
+        end else begin
+            ib_cache32_next = ib_cache32_r;
+        end
+        
+
+        if (do_write && access_addr == 5'h0C && dc_select == 2) begin
+            fx_cache_byte_index_next = write_data[3:2];
+        end else
+        if (do_read && !fx_cache_fill_enabled_r && access_addr == 5'h03 && fx_addr1_mode_r == MODE_POLY_FILL && fx_one_byte_cache_cycling_r) begin
+            // We also want to increment the cache byte index if one_byte_cache_cycling is turned on
+            if (fx_cache_increment_mode_r) begin
+                fx_cache_byte_index_next[0] = !fx_cache_byte_index_r[0]; // loop: 0 -> 1 -> 0 ... or 2 -> 3 -> 2 ...
+            end else begin
+                fx_cache_byte_index_next = fx_cache_byte_index_r + 2'd1;  // loop: 0 -> 1 -> 2 -> 3 -> 0 ...
+            end
+        end else 
+        if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04)) begin
+            if (fx_cache_increment_mode_r) begin
+                fx_cache_byte_index_next[0] = !fx_cache_byte_index_r[0]; // loop: 0 -> 1 -> 0 ... or 2 -> 3 -> 2 ...
+            end else begin
+                fx_cache_byte_index_next = fx_cache_byte_index_r + 2'd1;  // loop: 0 -> 1 -> 2 -> 3 -> 0 ...
+            end
+        end
+
         if ((do_write || do_read) && (access_addr == 5'h03 || access_addr == 5'h04)) begin
             ib_write_next  = do_write;
         end
 
         if (do_write && (access_addr == 5'h03 || access_addr == 5'h04)) begin
+            
             ib_wrdata_next = write_data;
             ib_addr_next = access_addr == 5'h03 ? vram_addr_0_r : vram_addr_1_r;
             ib_do_access_next = 1;
+                
+            // Only when writing to *main* VRAM do we allow multibyte cache writes or transparancy
+            if (!is_audio_address && !is_palette_address && !is_sprite_attr_address) begin
+                ib_cache_write_enabled_next     = fx_cache_write_enabled_r;
+                ib_one_byte_cache_cycling_next  = fx_one_byte_cache_cycling_r;
+                ib_transparency_enabled_next    = fx_transparency_enabled_r;
+            end 
+
         end
 
         //////////////////////////////////////////////////////////////////////////
@@ -432,6 +574,11 @@ module addr_data(
         //////////////////////////////////////////////////////////////////////////
         
         if (do_write && access_addr == 5'h09 && dc_select == 2) begin
+            fx_transparency_enabled_next = write_data[7];
+            fx_cache_write_enabled_next = write_data[6];
+            fx_cache_fill_enabled_next = write_data[5];
+            fx_one_byte_cache_cycling_next = write_data[4];
+            fx_16bit_hop_next = write_data[3];
             fx_addr1_mode_next = write_data[1:0];
         end
         if (do_write && access_addr == 5'h0A && dc_select == 2) begin
@@ -442,6 +589,16 @@ module addr_data(
             fx_map_base_address_next = write_data[7:2];
             fx_map_size_next = write_data[1:0];
         end 
+        if (do_write && access_addr == 5'h0C && dc_select == 2) begin
+            fx_reset_accum_next = write_data[7];
+            fx_accumulate_next = write_data[6];
+            fx_add_or_sub_next = write_data[5];
+            fx_mult_enabled_next = write_data[4];
+            // fx_cache_byte_index_next is set above
+            fx_cache_increment_mode_next = write_data[0];
+        end 
+        
+        
         if (do_write && access_addr == 5'h09 && dc_select == 3) begin
             fx_pixel_incr_x_next[7:0] = write_data;
         end 
@@ -502,6 +659,28 @@ module addr_data(
            // Not writable (read-only)
         end 
         
+
+        if (do_read && access_addr == 5'h09 && dc_select == 6) begin
+            fx_reset_accum_next = 1;
+        end 
+        if (do_read && access_addr == 5'h0A && dc_select == 6) begin
+            fx_accumulate_next = 1;
+        end 
+
+        // Direct access to the cache32
+        if (do_write && access_addr == 5'h09 && dc_select == 6) begin
+            ib_cache32_next[7:0] = write_data;
+        end
+        if (do_write && access_addr == 5'h0A && dc_select == 6) begin
+            ib_cache32_next[15:8] = write_data;
+        end
+        if (do_write && access_addr == 5'h0B && dc_select == 6) begin
+            ib_cache32_next[23:16] = write_data;
+        end
+        if (do_write && access_addr == 5'h0C && dc_select == 6) begin
+            ib_cache32_next[31:24] = write_data;
+        end
+
         //////////////////////////////////////////////////////////////////////////
         // Tile map calculations
         //////////////////////////////////////////////////////////////////////////
@@ -647,12 +826,20 @@ module addr_data(
             vram_data1_r                  <= 0;
 
             fx_addr1_mode_r               <= 0;
+            fx_16bit_hop_r                <= 0;
+            fx_mult_enabled_r             <= 0;
+            fx_reset_accum_r                <= 0;
+            fx_accumulate_r               <= 0;
+            fx_add_or_sub_r               <= 0;
         
             fx_tiledata_base_address_r    <= 0;
             fx_map_base_address_r         <= 0;
             fx_apply_clip_r               <= 0;
             
             fx_map_size_r                 <= 0;
+            fx_cache_fill_enabled_r       <= 0;
+            fx_cache_increment_mode_r     <= 0;
+            fx_cache_byte_index_r         <= 0;
             
             fx_pixel_pos_x_r              <= 20'd256; // half a pixel
             fx_pixel_pos_y_r              <= 20'd256; // half a pixel
@@ -662,13 +849,23 @@ module addr_data(
         
             fx_pixel_incr_x_r             <= 0;
             fx_pixel_incr_y_r             <= 0;
+
+            fx_cache_write_enabled_r      <= 0;
+            fx_transparency_enabled_r     <= 0;
+            fx_one_byte_cache_cycling_r   <= 0;
             
             fx_use_result_as_tileindex_r  <= 0;
             fx_calculate_addr1_based_on_position_r <= 0;
             fx_increment_on_overflow_r    <= 0;
             fx_calculate_addr1_based_on_tileindex_r <= 0;
+            fx_16bit_hop_start_index_r    <= 0;
 
             ib_addr_r                     <= 0;
+            ib_cache_write_enabled_r      <= 0;
+            ib_transparency_enabled_r     <= 0;
+            ib_one_byte_cache_cycling_r   <= 0;
+            ib_cache32_r                  <= 0;
+            
             ib_wrdata_r                   <= 0;
             ib_do_access_r                <= 0;
             ib_write_r                    <= 0;
@@ -689,12 +886,20 @@ module addr_data(
             vram_data1_r                  <= vram_data1_next;
 
             fx_addr1_mode_r               <= fx_addr1_mode_next;
+            fx_16bit_hop_r                <= fx_16bit_hop_next;
+            fx_mult_enabled_r             <= fx_mult_enabled_next;
+            fx_reset_accum_r              <= fx_reset_accum_next;
+            fx_accumulate_r               <= fx_accumulate_next;
+            fx_add_or_sub_r               <= fx_add_or_sub_next;
             
             fx_tiledata_base_address_r    <= fx_tiledata_base_address_next;
             fx_map_base_address_r         <= fx_map_base_address_next;
             fx_apply_clip_r               <= fx_apply_clip_next;
             
             fx_map_size_r                 <= fx_map_size_next;
+            fx_cache_fill_enabled_r       <= fx_cache_fill_enabled_next;
+            fx_cache_increment_mode_r     <= fx_cache_increment_mode_next;
+            fx_cache_byte_index_r         <= fx_cache_byte_index_next;
             
             fx_pixel_pos_x_r              <= fx_pixel_pos_x_next;
             fx_pixel_pos_y_r              <= fx_pixel_pos_y_next;
@@ -705,12 +910,22 @@ module addr_data(
             fx_pixel_incr_x_r             <= fx_pixel_incr_x_next;
             fx_pixel_incr_y_r             <= fx_pixel_incr_y_next;
             
+            fx_cache_write_enabled_r      <= fx_cache_write_enabled_next;
+            fx_transparency_enabled_r     <= fx_transparency_enabled_next;
+            fx_one_byte_cache_cycling_r   <= fx_one_byte_cache_cycling_next;
+            
             fx_use_result_as_tileindex_r  <= fx_use_result_as_tileindex_next;
             fx_calculate_addr1_based_on_position_r <= fx_calculate_addr1_based_on_position_next;
             fx_increment_on_overflow_r    <= fx_increment_on_overflow_next;
             fx_calculate_addr1_based_on_tileindex_r <= fx_calculate_addr1_based_on_tileindex_next;
+            fx_16bit_hop_start_index_r    <= fx_16bit_hop_start_index_next;
 
             ib_addr_r                     <= ib_addr_next;
+            ib_cache_write_enabled_r      <= ib_cache_write_enabled_next;
+            ib_transparency_enabled_r     <= ib_transparency_enabled_next;
+            ib_one_byte_cache_cycling_r   <= ib_one_byte_cache_cycling_next;
+            ib_cache32_r                  <= ib_cache32_next;
+
             ib_wrdata_r                   <= ib_wrdata_next;
             ib_do_access_r                <= ib_do_access_next;
             ib_write_r                    <= ib_write_next;
@@ -722,5 +937,21 @@ module addr_data(
             save_result_port_r            <= fetch_ahead_port_r;
         end
     end
+
+
+    //////////////////////////////////////////////////////////////////////////
+    // MULTIPLIER / ACCUMULATOR
+    //////////////////////////////////////////////////////////////////////////
+    
+    mult_accum mult_accum(
+        .clk(clk),
+        .input_a_16(ib_cache32_r[15:0]),
+        .input_b_16(ib_cache32_r[31:16]),
+        .mult_enabled(fx_mult_enabled_r),
+        .reset_accum(fx_reset_accum_r),
+        .accumulate(fx_accumulate_r),
+        .add_or_sub(fx_add_or_sub_r),
+        .output_32(ib_mult_accum_cache32)
+    );
     
 endmodule

--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -22,7 +22,7 @@ module pcm(
 
     // Audio output
     output wire [15:0] left_audio,
-    output wire [15:0] right_audio);
+    output wire [15:0] right_audio) /* synthesis syn_hier = "hard" */;
 
     //////////////////////////////////////////////////////////////////////////
     // Audio FIFO

--- a/fpga/source/audio/psg.v
+++ b/fpga/source/audio/psg.v
@@ -13,7 +13,7 @@ module psg(
 
     // Audio output
     output wire [15:0] left_audio,
-    output wire [15:0] right_audio);
+    output wire [15:0] right_audio) /* synthesis syn_hier = "hard" */;
 
     //////////////////////////////////////////////////////////////////////////
     // Audio attribute RAM

--- a/fpga/source/main_ram.v
+++ b/fpga/source/main_ram.v
@@ -6,9 +6,9 @@ module main_ram(
     // Slave bus interface
     input  wire [14:0] bus_addr,
     input  wire [31:0] bus_wrdata,
-    input  wire  [3:0] bus_wrbytesel,
+    input  wire  [7:0] bus_wrnibblesel,
     output reg  [31:0] bus_rddata,
-    input  wire        bus_write);
+    input  wire        bus_write) /* synthesis syn_hier = "hard" */;
 
     wire blk10_cs = !bus_addr[14];
     wire blk32_cs = bus_addr[14];
@@ -32,31 +32,55 @@ module main_ram(
 
     always @(posedge clk) begin
         if (bus_write && blk10_cs) begin
-            if (bus_wrbytesel[0]) begin
-                blk10[bus_addr][7:0] = bus_wrdata[7:0];
+            if (bus_wrnibblesel[0]) begin
+                blk10[bus_addr][3:0] = bus_wrdata[3:0];
             end
-            if (bus_wrbytesel[1]) begin
-                blk10[bus_addr][15:8] = bus_wrdata[15:8];
+            if (bus_wrnibblesel[1]) begin
+                blk10[bus_addr][7:4] = bus_wrdata[7:4];
             end
-            if (bus_wrbytesel[2]) begin
-                blk10[bus_addr][23:16] = bus_wrdata[23:16];
+            if (bus_wrnibblesel[2]) begin
+                blk10[bus_addr][11:8] = bus_wrdata[11:8];
             end
-            if (bus_wrbytesel[3]) begin
-                blk10[bus_addr][31:24] = bus_wrdata[31:24];
+            if (bus_wrnibblesel[3]) begin
+                blk10[bus_addr][15:12] = bus_wrdata[15:12];
+            end
+            if (bus_wrnibblesel[4]) begin
+                blk10[bus_addr][19:16] = bus_wrdata[19:16];
+            end
+            if (bus_wrnibblesel[5]) begin
+                blk10[bus_addr][23:20] = bus_wrdata[23:20];
+            end
+            if (bus_wrnibblesel[6]) begin
+                blk10[bus_addr][27:24] = bus_wrdata[27:24];
+            end
+            if (bus_wrnibblesel[7]) begin
+                blk10[bus_addr][31:28] = bus_wrdata[31:28];
             end
         end
         if (bus_write && blk32_cs) begin
-            if (bus_wrbytesel[0]) begin
-                blk32[bus_addr][7:0] = bus_wrdata[7:0];
+            if (bus_wrnibblesel[0]) begin
+                blk32[bus_addr][3:0] = bus_wrdata[3:0];
             end
-            if (bus_wrbytesel[1]) begin
-                blk32[bus_addr][15:8] = bus_wrdata[15:8];
+            if (bus_wrnibblesel[1]) begin
+                blk32[bus_addr][7:4] = bus_wrdata[7:4];
             end
-            if (bus_wrbytesel[2]) begin
-                blk32[bus_addr][23:16] = bus_wrdata[23:16];
+            if (bus_wrnibblesel[2]) begin
+                blk32[bus_addr][11:8] = bus_wrdata[11:8];
             end
-            if (bus_wrbytesel[3]) begin
-                blk32[bus_addr][31:24] = bus_wrdata[31:24];
+            if (bus_wrnibblesel[3]) begin
+                blk32[bus_addr][15:12] = bus_wrdata[15:12];
+            end
+            if (bus_wrnibblesel[4]) begin
+                blk32[bus_addr][19:16] = bus_wrdata[19:16];
+            end
+            if (bus_wrnibblesel[5]) begin
+                blk32[bus_addr][23:20] = bus_wrdata[23:20];
+            end
+            if (bus_wrnibblesel[6]) begin
+                blk32[bus_addr][27:24] = bus_wrdata[27:24];
+            end
+            if (bus_wrnibblesel[7]) begin
+                blk32[bus_addr][31:28] = bus_wrdata[31:28];
             end
         end
 
@@ -86,7 +110,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[15:0]),
         .DO(blk10_rddata[15:0]),
-        .MASKWE({{2{bus_wrbytesel[1]}}, {2{bus_wrbytesel[0]}}}),
+        .MASKWE(bus_wrnibblesel[3:0]),
         .WE(bus_write && blk10_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -98,7 +122,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[31:16]),
         .DO(blk10_rddata[31:16]),
-        .MASKWE({{2{bus_wrbytesel[3]}}, {2{bus_wrbytesel[2]}}}),
+        .MASKWE(bus_wrnibblesel[7:4]),
         .WE(bus_write && blk10_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -110,7 +134,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[15:0]),
         .DO(blk32_rddata[15:0]),
-        .MASKWE({{2{bus_wrbytesel[1]}}, {2{bus_wrbytesel[0]}}}),
+        .MASKWE(bus_wrnibblesel[3:0]),
         .WE(bus_write && blk32_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -122,7 +146,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[31:16]),
         .DO(blk32_rddata[31:16]),
-        .MASKWE({{2{bus_wrbytesel[3]}}, {2{bus_wrbytesel[2]}}}),
+        .MASKWE(bus_wrnibblesel[7:4]),
         .WE(bus_write && blk32_cs),
         .CS(1'b1),
         .STDBY(1'b0),

--- a/fpga/source/mult_accum.v
+++ b/fpga/source/mult_accum.v
@@ -1,0 +1,57 @@
+//`default_nettype none
+
+module mult_accum (
+    input  wire        clk,
+    
+    input  wire [15:0] input_a_16,
+    input  wire [15:0] input_b_16,
+    input  wire        mult_enabled,
+    input  wire        reset_accum,
+    input  wire        accumulate,
+    input  wire        add_or_sub,
+    
+    output wire [31:0] output_32);
+    
+    pmi_dsp i_mult16x16 ( // port interfaces
+        .A(input_a_16),
+        .B(input_b_16),
+        .C(input_b_16), // This is used to pass through the original value of the cache
+        .D(input_a_16), // This is used to pass through the original value of the cache
+        .O(output_32),
+        .CLK(clk),
+        .CE(1'b1),
+        .IRSTTOP(1'b0),
+        .IRSTBOT(1'b0),
+        .ORSTTOP(reset_accum),
+        .ORSTBOT(reset_accum),
+        .AHOLD(1'b0),
+        .BHOLD(1'b0),
+        .CHOLD(1'b0),
+        .DHOLD(1'b0),
+        .OHOLDTOP(!accumulate),
+        .OHOLDBOT(!accumulate),
+        .OLOADTOP(!mult_enabled), // We are using the LOAD to switch between the multiplier output and (effectively) input C
+        .OLOADBOT(!mult_enabled), // We are using the LOAD to switch between the multiplier output and (effectively) input D
+        .ADDSUBTOP(add_or_sub),
+        .ADDSUBBOT(add_or_sub),
+        .CO(),
+        .CI(1'b0),  
+        .ACCUMCI(1'b0),
+        .ACCUMCO(),
+        .SIGNEXTIN(1'b0),
+        .SIGNEXTOUT()
+    );
+    defparam i_mult16x16.TOPOUTPUT_SELECT = 2'b00; // Adder output (non registered)
+    defparam i_mult16x16.BOTOUTPUT_SELECT = 2'b00; // Adder output (non registered)
+    defparam i_mult16x16.A_SIGNED = 1'b1; //Signed Inputs
+    defparam i_mult16x16.B_SIGNED = 1'b1;
+    
+    defparam i_mult16x16.TOPADDSUB_CARRYSELECT  = 2'b10; // 10: Cascade ACCUMOUT from lower Adder/Subtractor
+    
+    defparam i_mult16x16.TOPADDSUB_LOWERINPUT = 2'b10; // We send the output (the 16 upper bits) of the 16x16 multiplier to the lower side of the top accumilator
+    defparam i_mult16x16.TOPADDSUB_UPPERINPUT = 1'b0;  // We send the output of the top (output) flip-flop to the upper side of the top accumilator
+    defparam i_mult16x16.BOTADDSUB_LOWERINPUT = 2'b10; // We send the output (the 16 lower bits) of the 16x16 multiplier to the lower side of the bottom accumilator
+    defparam i_mult16x16.BOTADDSUB_UPPERINPUT = 1'b0;  // We send the output of the bottom (output) flip-flop to the upper side of the top accumilator
+    
+    
+endmodule

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -56,6 +56,11 @@ module top(
     wire  [7:0] vram_data1_r;
     
     wire [16:0] ib_addr_r;
+    wire        ib_cache_write_enabled_r;
+    wire        ib_transparency_enabled_r;
+    wire        ib_one_byte_cache_cycling_r;
+    wire [31:0] ib_mult_accum_cache32_r;
+    wire  [7:0] ib_cache8_r;
     wire  [7:0] ib_wrdata_r;
     wire        ib_write_r;
     wire        ib_do_access_r;
@@ -63,6 +68,11 @@ module top(
     wire  [7:0] fx_fill_length_low;
     wire  [7:0] fx_fill_length_high;
     
+    wire        fx_transparency_enabled;
+    wire        fx_cache_write_enabled;
+    wire        fx_cache_fill_enabled;
+    wire        fx_one_byte_cache_cycling;
+    wire        fx_16bit_hop;
     wire  [1:0] fx_addr1_mode;
 
     reg        vram_addr_select_r,            vram_addr_select_next;
@@ -161,7 +171,7 @@ module top(
             case(dc_select_r)
                 6'h0: rddata = {current_field, sprites_enabled_r, l1_enabled_r, l0_enabled_r, line_interlace_mode_r, chroma_disable_r, video_output_mode_r};
                 6'h1: rddata = dc_active_hstart_r[9:2];
-                6'h2: rddata = {6'b0, fx_addr1_mode};
+                6'h2: rddata = {fx_transparency_enabled, fx_cache_write_enabled, fx_cache_fill_enabled, fx_one_byte_cache_cycling, fx_16bit_hop, 1'b0, fx_addr1_mode};
                 default: rddata = "V";
             endcase
         end
@@ -611,10 +621,20 @@ module top(
         .vram_data1(vram_data1_r),
         
         .ib_addr(ib_addr_r),
+        .ib_cache_write_enabled(ib_cache_write_enabled_r),
+        .ib_transparency_enabled(ib_transparency_enabled_r),
+        .ib_one_byte_cache_cycling(ib_one_byte_cache_cycling_r),
+        .ib_mult_accum_cache32(ib_mult_accum_cache32_r),
+        .ib_cache8(ib_cache8_r),
         .ib_wrdata(ib_wrdata_r),
         .ib_do_access(ib_do_access_r),
         .ib_write(ib_write_r),
 
+        .fx_transparency_enabled(fx_transparency_enabled),
+        .fx_cache_write_enabled(fx_cache_write_enabled),
+        .fx_cache_fill_enabled(fx_cache_fill_enabled),
+        .fx_one_byte_cache_cycling(fx_one_byte_cache_cycling),
+        .fx_16bit_hop(fx_16bit_hop),
         .fx_addr1_mode(fx_addr1_mode),
     
         .fx_fill_length_low(fx_fill_length_low),
@@ -644,6 +664,11 @@ module top(
 
         // Interface 0 - 8-bit (highest priority)
         .if0_addr(ib_addr_r),
+        .if0_cache_write_enabled(ib_cache_write_enabled_r),
+        .if0_transparency_enabled(ib_transparency_enabled_r),
+        .if0_one_byte_cache_cycling(ib_one_byte_cache_cycling_r),
+        .if0_mult_accum_cache32(ib_mult_accum_cache32_r),
+        .if0_cache8(ib_cache8_r),
         .if0_wrdata(ib_wrdata_r),
         .if0_rddata(vram_rddata),
         .if0_strobe(ib_do_access_r),

--- a/fpga/source/video/video_composite.v
+++ b/fpga/source/video/video_composite.v
@@ -25,7 +25,7 @@ module video_composite(
     output wire  [3:0] rgb_b,
     output wire        rgb_sync_n,
     output wire        rgb_hsync,
-    output wire        rgb_vsync);
+    output wire        rgb_vsync) /* synthesis syn_hier = "hard" */;
 
     //
     // Video timing (NTSC 60Hz)

--- a/fpga/source/video/video_modulator.v
+++ b/fpga/source/video/video_modulator.v
@@ -11,7 +11,7 @@ module video_modulator(
     input  wire        sync_n_in,
 
     output reg   [5:0] luma,
-    output reg   [5:0] chroma);
+    output reg   [5:0] chroma) /* synthesis syn_hier = "hard" */;
 
     parameter Y_R   = 27; // 38; //  0.299
     parameter Y_G   = 53; // 75; //  0.587

--- a/fpga/source/vram_if.v
+++ b/fpga/source/vram_if.v
@@ -5,6 +5,11 @@ module vram_if(
 
     // Interface 0 - 8-bit (highest priority)
     input  wire [16:0] if0_addr,
+    input  wire        if0_cache_write_enabled,
+    input  wire        if0_transparency_enabled,
+    input  wire        if0_one_byte_cache_cycling,
+    input  wire  [7:0] if0_cache8,
+    input  wire [31:0] if0_mult_accum_cache32,
     input  wire  [7:0] if0_wrdata,
     output wire  [7:0] if0_rddata,
     input  wire        if0_strobe,
@@ -26,14 +31,14 @@ module vram_if(
     input  wire [14:0] if3_addr,
     output wire [31:0] if3_rddata,
     input  wire        if3_strobe,
-    output reg         if3_ack);
+    output reg         if3_ack) /* synthesis syn_hier = "hard" */;
 
     //////////////////////////////////////////////////////////////////////////
     // Main RAM 128kB (32k x 32)
     //////////////////////////////////////////////////////////////////////////
     reg  [14:0] ram_addr;
-    wire [31:0] ram_wrdata;
-    reg   [3:0] ram_wrbytesel;
+    reg  [31:0] ram_wrdata;
+    reg   [7:0] ram_wrnibblesel;
     wire [31:0] ram_rddata;
     wire        ram_write;
 
@@ -41,7 +46,7 @@ module vram_if(
         .clk(clk),
         .bus_addr(ram_addr),
         .bus_wrdata(ram_wrdata),
-        .bus_wrbytesel(ram_wrbytesel),
+        .bus_wrnibblesel(ram_wrnibblesel),
         .bus_rddata(ram_rddata),
         .bus_write(ram_write));
 
@@ -52,16 +57,66 @@ module vram_if(
     reg if1_ack_next;
     reg if2_ack_next;
     reg if3_ack_next;
-
-    assign ram_wrdata = {4{if0_wrdata}};
+    
+    reg [1:0] byte_0_transparency_nibblesel;
+    reg [1:0] byte_1_transparency_nibblesel;
+    reg [1:0] byte_2_transparency_nibblesel;
+    reg [1:0] byte_3_transparency_nibblesel;
+    
+    reg [1:0] byte_transparancy_nibblesel;
+    
+    reg [7:0] if0_wrdata_to_use /* synthesis syn_keep=1 */;
+    
     assign ram_write  = if0_strobe && if0_write;
 
-    always @* case (if0_addr[1:0])
-        2'b00: ram_wrbytesel = 4'b0001;
-        2'b01: ram_wrbytesel = 4'b0010;
-        2'b10: ram_wrbytesel = 4'b0100;
-        2'b11: ram_wrbytesel = 4'b1000;
-    endcase
+    always @* begin
+        
+        if (if0_one_byte_cache_cycling) begin
+            if0_wrdata_to_use = if0_cache8;
+        end else begin
+            if0_wrdata_to_use = if0_wrdata;
+        end
+        
+        if (if0_cache_write_enabled && !if0_one_byte_cache_cycling) begin
+            // In cache write mode, we use the 32-bit data from the cache
+            ram_wrdata = if0_mult_accum_cache32;
+        end else begin
+            // In non-cache write mode, we use the wrdata and duplicate to all four 8-bit channels
+            ram_wrdata = {4{if0_wrdata_to_use}};
+        end
+        
+        if (if0_cache_write_enabled) begin
+            // In cache write mode, we use the 32-bit data from the cache
+            if (if0_transparency_enabled) begin
+                
+                byte_3_transparency_nibblesel = ram_wrdata[31:24] == 0 ? 2'b00 : 2'b11;
+                byte_2_transparency_nibblesel = ram_wrdata[23:16] == 0 ? 2'b00 : 2'b11;
+                byte_1_transparency_nibblesel = ram_wrdata[15:8] == 0 ? 2'b00 : 2'b11;
+                byte_0_transparency_nibblesel = ram_wrdata[7:0] == 0 ? 2'b00 : 2'b11;
+                
+                // In transparent cache write mode, we check each byte (or nibble) we are writing: if its 0, its considered transparent and not written to VRAM
+                ram_wrnibblesel = {byte_3_transparency_nibblesel,
+                                   byte_2_transparency_nibblesel,
+                                   byte_1_transparency_nibblesel,
+                                   byte_0_transparency_nibblesel};
+            end else begin
+                // In normal cache write mode, we invert the byte written to us and use it as a nibble mask
+                ram_wrnibblesel = ~if0_wrdata; 
+            end
+        end else begin
+            // In non-cache write mode, we check the byte we are writing: if its 0, its considered transparent and not written to VRAM
+            byte_transparancy_nibblesel = (if0_transparency_enabled && if0_wrdata_to_use == 0) ? 2'b00 : 2'b11;
+
+            // In non-cache write mode, we write the byte correspronding to the addr[1:0], unless we are in transparant mode and write a 0
+            case (if0_addr[1:0])
+                2'b00: ram_wrnibblesel = { 6'b000000, byte_transparancy_nibblesel };
+                2'b01: ram_wrnibblesel = { 4'b0000, byte_transparancy_nibblesel, 2'b00 };
+                2'b10: ram_wrnibblesel = { 2'b00, byte_transparancy_nibblesel, 4'b0000 };
+                2'b11: ram_wrnibblesel = { byte_transparancy_nibblesel, 6'b000000 };
+            endcase
+        end
+
+    end
 
     always @* begin
         ram_addr     = 15'b0;

--- a/fpga/vera_module.rdf
+++ b/fpga/vera_module.rdf
@@ -78,6 +78,9 @@
         <Source name="source/audio/pcm.v" type="Verilog" type_short="Verilog">
             <Options/>
         </Source>
+        <Source name="source/mult_accum.v" type="Verilog" type_short="Verilog">
+            <Options/>
+        </Source>
         <Source name="source/vera_module.ldc" type="LSE Design Constraints File" type_short="LDC">
             <Options/>
         </Source>


### PR DESCRIPTION
In this PR the 32-bit cache and the multiplier/accumularor is added to the fx branch.

It does the following things:

- adds the multiplier and accumulator
- adds the 32-bit cache
- adds cache filling (one byte at the time) 
- adds cache writing (4 bytes at the time, ability to mask on the nibble level)
- adds one byte cache cycling
- adds 16-bit hopping (for +4 and +320 increments of ADDR1)
- adds transparency writes (for 32-bit cache writes as well as normal 8-bit writes)
- LUT reduction: adds "hints" to the optimizer in order for it to not get stuck in local minimum, saving a lot of LUTs. (by adding "syn_hier" and "syn_keep" attributes in specific comments). For more detail you can read [this documentation](https://www.microsemi.com/document-portal/doc_view/134092-synopsys-fpga-synthesis-attribute-reference-manual-i-2013-09m-sp1-1).

Note that this PR still only contains the 8-bit version of cache filling and transparency. The 4-bit versions will follow later on. This is to keep the PRs as small as possible.

--
Sidenote: due to the need for merging back and forth between forks, commits of earlier PRs are in this PR. It is there best to concentrate on the actual file differences.