### PR TITLE
4-bit and 2-bit modes

### DIFF
--- a/fpga/source/addr_data.v
+++ b/fpga/source/addr_data.v
@@ -15,14 +15,20 @@ module addr_data(
 
     output wire [16:0] vram_addr_0,
     output wire [16:0] vram_addr_1,
+    output wire        vram_addr_nib_0,
+    output wire        vram_addr_nib_1,
     output wire  [3:0] vram_addr_incr_0,
     output wire  [3:0] vram_addr_incr_1,
+    output wire        vram_addr_nib_incr_0,
+    output wire        vram_addr_nib_incr_1,
     output wire        vram_addr_decr_0,
     output wire        vram_addr_decr_1,
     output wire  [7:0] vram_data0,
     output wire  [7:0] vram_data1,
 
     output wire [16:0] ib_addr,
+    output wire        ib_addr_nibble,
+    output wire        ib_4bit_mode,
     output wire        ib_cache_write_enabled,
     output wire        ib_transparency_enabled,
     output wire        ib_one_byte_cache_cycling,
@@ -37,6 +43,7 @@ module addr_data(
     output wire        fx_cache_fill_enabled,
     output wire        fx_one_byte_cache_cycling,
     output wire        fx_16bit_hop,
+    output wire        fx_4bit_mode,
     output wire  [1:0] fx_addr1_mode,
     
     output reg   [7:0] fx_fill_length_low,
@@ -50,8 +57,12 @@ module addr_data(
 
     reg [16:0] vram_addr_0_r,                 vram_addr_0_next;
     reg [16:0] vram_addr_1_r,                 vram_addr_1_next;
+    reg        vram_addr_nib_0_r,             vram_addr_nib_0_next;
+    reg        vram_addr_nib_1_r,             vram_addr_nib_1_next;
     reg  [3:0] vram_addr_incr_0_r,            vram_addr_incr_0_next;
     reg  [3:0] vram_addr_incr_1_r,            vram_addr_incr_1_next;
+    reg        vram_addr_nib_incr_0_r,        vram_addr_nib_incr_0_next;
+    reg        vram_addr_nib_incr_1_r,        vram_addr_nib_incr_1_next;
     reg        vram_addr_decr_0_r,            vram_addr_decr_0_next;
     reg        vram_addr_decr_1_r,            vram_addr_decr_1_next;
     reg  [7:0] vram_data0_r,                  vram_data0_next;
@@ -59,14 +70,20 @@ module addr_data(
     
     assign vram_addr_0 = vram_addr_0_r;
     assign vram_addr_1 = vram_addr_1_r;
+    assign vram_addr_nib_0 = vram_addr_nib_0_r;
+    assign vram_addr_nib_1 = vram_addr_nib_1_r;
     assign vram_addr_incr_0 = vram_addr_incr_0_r;
     assign vram_addr_incr_1 = vram_addr_incr_1_r;
+    assign vram_addr_nib_incr_0 = vram_addr_nib_incr_0_r;
+    assign vram_addr_nib_incr_1 = vram_addr_nib_incr_1_r;
     assign vram_addr_decr_0 = vram_addr_decr_0_r;
     assign vram_addr_decr_1 = vram_addr_decr_1_r;
     assign vram_data0 = vram_data0_r;
     assign vram_data1 = vram_data1_r;
 
     reg  [16:0] ib_addr_r,                   ib_addr_next;
+    reg         ib_addr_nibble_r,            ib_addr_nibble_next;
+    reg         ib_4bit_mode_r,              ib_4bit_mode_next;
     reg         ib_cache_write_enabled_r,    ib_cache_write_enabled_next;
     reg         ib_transparency_enabled_r,   ib_transparency_enabled_next;
     reg         ib_one_byte_cache_cycling_r, ib_one_byte_cache_cycling_next;
@@ -76,6 +93,8 @@ module addr_data(
     reg         ib_do_access_r,              ib_do_access_next;
 
     assign ib_addr = ib_addr_r;
+    assign ib_addr_nibble = ib_addr_nibble_r;
+    assign ib_4bit_mode = ib_4bit_mode_r;
     assign ib_transparency_enabled = ib_transparency_enabled_r;
     assign ib_one_byte_cache_cycling = ib_one_byte_cache_cycling_r;
     assign ib_cache_write_enabled = ib_cache_write_enabled_r;
@@ -103,6 +122,7 @@ module addr_data(
 
 
     reg  [1:0] fx_addr1_mode_r,               fx_addr1_mode_next;
+    reg        fx_4bit_mode_r,                fx_4bit_mode_next;
     reg        fx_16bit_hop_r,                fx_16bit_hop_next;
     reg        fx_mult_enabled_r,             fx_mult_enabled_next;
     reg        fx_reset_accum_r,              fx_reset_accum_next;
@@ -110,11 +130,13 @@ module addr_data(
     reg        fx_add_or_sub_r,               fx_add_or_sub_next;
     
     reg  [5:0] fx_tiledata_base_address_r,    fx_tiledata_base_address_next;
+    reg        fx_2bit_polygon_pixels_r,      fx_2bit_polygon_pixels_next;
     reg  [5:0] fx_map_base_address_r,         fx_map_base_address_next;
     reg        fx_apply_clip_r,               fx_apply_clip_next;
     
     reg  [1:0] fx_map_size_r,                 fx_map_size_next;
     reg  [1:0] fx_cache_byte_index_r,         fx_cache_byte_index_next;
+    reg        fx_cache_nibble_index_r,       fx_cache_nibble_index_next;
     
     reg        fx_cache_increment_mode_r,     fx_cache_increment_mode_next;
     reg        fx_cache_fill_enabled_r,       fx_cache_fill_enabled_next;
@@ -136,6 +158,7 @@ module addr_data(
     reg        fx_transparency_enabled_r,     fx_transparency_enabled_next;
     reg        fx_one_byte_cache_cycling_r,   fx_one_byte_cache_cycling_next;
     
+    reg        fx_2bit_poke_mode_r,           fx_2bit_poke_mode_next;
     reg  [1:0] fx_16bit_hop_start_index_r,    fx_16bit_hop_start_index_next;
 
     assign fx_transparency_enabled = fx_transparency_enabled_r;
@@ -143,54 +166,63 @@ module addr_data(
     assign fx_cache_fill_enabled = fx_cache_fill_enabled_r;
     assign fx_one_byte_cache_cycling = fx_one_byte_cache_cycling_r;
     assign fx_16bit_hop = fx_16bit_hop_r;
+    assign fx_4bit_mode = fx_4bit_mode_r;
     assign fx_addr1_mode = fx_addr1_mode_r;
 
     //////////////////////////////////////////////////////////////////////////
     // Address incrementers
     //////////////////////////////////////////////////////////////////////////
     
-    reg signed [10:0] incr_decr_0;
-    always @* case ({vram_addr_decr_0_r, vram_addr_incr_0_r})
-        5'h00: incr_decr_0 = 11'd0;
-        5'h01: incr_decr_0 = 11'd1;
-        5'h02: incr_decr_0 = 11'd2;
-        5'h03: incr_decr_0 = 11'd4;
-        5'h04: incr_decr_0 = 11'd8;
-        5'h05: incr_decr_0 = 11'd16;
-        5'h06: incr_decr_0 = 11'd32;
-        5'h07: incr_decr_0 = 11'd64;
-        5'h08: incr_decr_0 = 11'd128;
-        5'h09: incr_decr_0 = 11'd256;
-        5'h0A: incr_decr_0 = 11'd512;
-        5'h0B: incr_decr_0 = 11'd40;
-        5'h0C: incr_decr_0 = 11'd80;
-        5'h0D: incr_decr_0 = 11'd160;
-        5'h0E: incr_decr_0 = 11'd320;
-        5'h0F: incr_decr_0 = 11'd640;
-        5'h10: incr_decr_0 = -11'd0;
-        5'h11: incr_decr_0 = -11'd1;
-        5'h12: incr_decr_0 = -11'd2;
-        5'h13: incr_decr_0 = -11'd4;
-        5'h14: incr_decr_0 = -11'd8;
-        5'h15: incr_decr_0 = -11'd16;
-        5'h16: incr_decr_0 = -11'd32;
-        5'h17: incr_decr_0 = -11'd64;
-        5'h18: incr_decr_0 = -11'd128;
-        5'h19: incr_decr_0 = -11'd256;
-        5'h1A: incr_decr_0 = -11'd512;
-        5'h1B: incr_decr_0 = -11'd40;
-        5'h1C: incr_decr_0 = -11'd80;
-        5'h1D: incr_decr_0 = -11'd160;
-        5'h1E: incr_decr_0 = -11'd320;
-        5'h1F: incr_decr_0 = -11'd640;
-    endcase
+    reg  signed [10:0] incr_decr_0;
+    wire signed [10:0] incr_0_nib, decr_0_nib;
+    assign incr_0_nib  = vram_addr_nib_0_r ? 11'd1 : 11'd0; 
+    assign decr_0_nib  = vram_addr_nib_0_r ? 11'd0 : -11'd1; 
+    always @* begin
+        case ({vram_addr_decr_0_r, vram_addr_incr_0_r})
+            5'h00: incr_decr_0 = (fx_4bit_mode_r && vram_addr_nib_incr_0_r) ? incr_0_nib : 11'd0;
+            5'h01: incr_decr_0 = 11'd1;
+            5'h02: incr_decr_0 = 11'd2;
+            5'h03: incr_decr_0 = 11'd4;
+            5'h04: incr_decr_0 = 11'd8;
+            5'h05: incr_decr_0 = 11'd16;
+            5'h06: incr_decr_0 = 11'd32;
+            5'h07: incr_decr_0 = 11'd64;
+            5'h08: incr_decr_0 = 11'd128;
+            5'h09: incr_decr_0 = 11'd256;
+            5'h0A: incr_decr_0 = 11'd512;
+            5'h0B: incr_decr_0 = 11'd40;
+            5'h0C: incr_decr_0 = 11'd80;
+            5'h0D: incr_decr_0 = 11'd160;
+            5'h0E: incr_decr_0 = 11'd320;
+            5'h0F: incr_decr_0 = 11'd640;
+            5'h10: incr_decr_0 = (fx_4bit_mode_r && vram_addr_nib_incr_0_r) ? decr_0_nib : -11'd0;
+            5'h11: incr_decr_0 = -11'd1;
+            5'h12: incr_decr_0 = -11'd2;
+            5'h13: incr_decr_0 = -11'd4;
+            5'h14: incr_decr_0 = -11'd8;
+            5'h15: incr_decr_0 = -11'd16;
+            5'h16: incr_decr_0 = -11'd32;
+            5'h17: incr_decr_0 = -11'd64;
+            5'h18: incr_decr_0 = -11'd128;
+            5'h19: incr_decr_0 = -11'd256;
+            5'h1A: incr_decr_0 = -11'd512;
+            5'h1B: incr_decr_0 = -11'd40;
+            5'h1C: incr_decr_0 = -11'd80;
+            5'h1D: incr_decr_0 = -11'd160;
+            5'h1E: incr_decr_0 = -11'd320;
+            5'h1F: incr_decr_0 = -11'd640;
+        endcase
+    end
 
     reg  signed [10:0] incr_decr_1;
     wire signed [10:0] incr_1_16bit_hop_4;
     wire signed [10:0] incr_1_16bit_hop_320;
+    wire signed [10:0] incr_1_nib, decr_1_nib;
     
     assign incr_1_16bit_hop_4 = (vram_addr_1_r[1:0] == fx_16bit_hop_start_index_r) ? 11'd1 : 11'd3;
     assign incr_1_16bit_hop_320 = (vram_addr_1_r[1:0] == fx_16bit_hop_start_index_r) ? 11'd1 : 11'd319;
+    assign incr_1_nib  = vram_addr_nib_1_r ? 11'd1 : 11'd0; 
+    assign decr_1_nib  = vram_addr_nib_1_r ? 11'd0 : -11'd1; 
     always @* begin
         case ({vram_addr_decr_1_r, vram_addr_incr_1_r})
             5'h00: incr_decr_1 = 11'd0;
@@ -227,12 +259,18 @@ module addr_data(
             5'h1F: incr_decr_1 = -11'd640;
         endcase
         
+        if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h00) begin
+            incr_decr_1 = (fx_4bit_mode_r && vram_addr_nib_incr_1_r) ? incr_1_nib : 11'd0;
+        end 
         if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h03) begin
             incr_decr_1 = fx_16bit_hop_r ? incr_1_16bit_hop_4 : 11'd4;
         end 
         if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h0E) begin
             incr_decr_1 = fx_16bit_hop_r ? incr_1_16bit_hop_320 : 11'd320;
         end 
+        if ({vram_addr_decr_1_r, vram_addr_incr_1_r} == 5'h10) begin
+            incr_decr_1 = (fx_4bit_mode_r && vram_addr_nib_incr_1_r) ? decr_1_nib : -11'd0;
+        end
 
     end
 
@@ -240,6 +278,10 @@ module addr_data(
     wire [16:0] vram_addr_0_incr_decr_0  = vram_addr_0_r + { {6{incr_decr_0[10]}}, incr_decr_0} /* synthesis syn_keep=1 */;
     wire [16:0] vram_addr_1_incr_decr_1  = vram_addr_1_r + { {6{incr_decr_1[10]}}, incr_decr_1} /* synthesis syn_keep=1 */;
     wire [16:0] vram_addr_1_incr_decr_10 = vram_addr_1_incr_decr_1 + { {6{incr_decr_0[10]}}, incr_decr_0};
+
+     // We *flip* the nibble-bit if a nibble-incrementer is active
+    wire        vram_addr_nib_0_incr_decr_0  = vram_addr_nib_0_r ^ (fx_4bit_mode_r && vram_addr_nib_incr_0_r && !vram_addr_incr_0_r);
+    wire        vram_addr_nib_1_incr_decr_1  = vram_addr_nib_1_r ^ (fx_4bit_mode_r && vram_addr_nib_incr_1_r && !vram_addr_incr_1_r);
 
     //////////////////////////////////////////////////////////////////////////
     // Internal registers
@@ -258,15 +300,20 @@ module addr_data(
 
     reg  [16:0] vram_addr_0_untouched_or_set;
     reg         vram_addr_0_untouched_or_set_bit16;
+    reg         vram_addr_0_untouched_or_set_nibble;
     reg   [7:0] vram_addr_0_untouched_or_set_high, vram_addr_0_untouched_or_set_low;
         
     reg  [16:0] vram_addr_1_untouched_or_set;
     reg         vram_addr_1_untouched_or_set_bit16;
+    reg         vram_addr_1_untouched_or_set_nibble;
     reg   [7:0] vram_addr_1_untouched_or_set_high, vram_addr_1_untouched_or_set_low;
     
     reg  [16:0] vram_addr_1_tileindex_lookup /* synthesis syn_keep=1 */;
     reg  [16:0] vram_addr_1_tiledata_using_tilemap /* synthesis syn_keep=1 */;
     reg  [16:0] vram_addr_1_start_of_horizontal_fill_line /* synthesis syn_keep=1 */;
+    reg         vram_addr_nib_1_tiledata_using_tilemap;
+    reg         vram_addr_nib_1_tiledata_using_tilepos;
+    reg         vram_addr_nib_1_start_of_horizontal_fill_line;
     
     reg  [10:0] fx_pixel_position_in_map_x, fx_pixel_position_in_map_y;
     reg   [2:0] fx_pixel_position_in_tile_x, fx_pixel_position_in_tile_y;
@@ -275,7 +322,10 @@ module addr_data(
     reg   [7:0] fx_tile_index_looked_up;
     reg         fx_position_is_outside_map;
     
+    reg   [2:0] fx_cache_byte_and_nibble_incremented;
+    reg   [3:0] fx_nibble_to_be_loaded_into_cache;
     reg   [7:0] fx_byte_to_be_loaded_into_cache;
+    reg  [31:0] fx_cache_filled_with_nibble;
     reg  [31:0] fx_cache_filled_with_byte;
     
     reg  [1:0]  fx_vram_addr_0_needs_to_be_changed /* synthesis syn_keep=1 */;
@@ -302,22 +352,27 @@ module addr_data(
     wire [9:0] fx_fill_length = fx_pixel_pos_y_r[18:9] - fx_pixel_pos_x_r[18:9];
     
     wire       fx_fill_length_more_than_15 = fx_fill_length[9:4] != 0;
+    wire       fx_fill_length_more_than_7 = fx_fill_length[9:3] != 0;
     
-    // Note: If we have a negative number (or too high: upper 2 bits should never be 11b) we return 'zero' value and fill_length_more_than_15 = 1, to indicate we have an invalid value.
+    // Note: If we have a negative number (or too high: upper 2 bits should never be 11b) we return 'zero' value and fill_length_more_than_15/7 = 1, to indicate we have an invalid value.
     wire      fx_fill_length_overflow = fx_fill_length[9:8] == 2'b11;
+    wire      fx_2bit_polygon_filler_mode = fx_addr1_mode_r == MODE_POLY_FILL && fx_4bit_mode_r && fx_2bit_polygon_pixels_r; // 2-bit(ish) polygon filler mode
     
     always @* begin
         
         fx_fill_length_high = { fx_fill_length[9:3], 1'b0 };
 
-        fx_fill_length_low[0] = 1'b0;
-        fx_fill_length_low[1] = !fx_fill_length_overflow && fx_fill_length[0];
-        fx_fill_length_low[2] = !fx_fill_length_overflow && fx_fill_length[1];
-        fx_fill_length_low[3] = !fx_fill_length_overflow && fx_fill_length[2];
-        fx_fill_length_low[4] = !fx_fill_length_overflow && fx_fill_length[3];
-        fx_fill_length_low[5] = !fx_fill_length_overflow && fx_pixel_pos_x_r[9];
-        fx_fill_length_low[6] = !fx_fill_length_overflow && fx_pixel_pos_x_r[10];
-        fx_fill_length_low[7] = fx_fill_length_more_than_15;
+        fx_fill_length_low[0] = fx_2bit_polygon_filler_mode && fx_pixel_pos_x_r[8];
+        fx_fill_length_low[1] = (!fx_fill_length_overflow) && fx_fill_length[0];
+        fx_fill_length_low[2] = (!fx_fill_length_overflow) && fx_fill_length[1];
+        fx_fill_length_low[3] = (!fx_fill_length_overflow) && fx_fill_length[2];
+        fx_fill_length_low[4] = (!fx_fill_length_overflow && !fx_4bit_mode_r && fx_fill_length[3]) || 
+                                (!fx_fill_length_overflow && fx_4bit_mode_r && fx_pixel_pos_x_r[11]);
+        fx_fill_length_low[5] = (!fx_fill_length_overflow) && fx_pixel_pos_x_r[9];
+        fx_fill_length_low[6] = (!fx_fill_length_overflow) && fx_pixel_pos_x_r[10];
+        fx_fill_length_low[7] = (                               !fx_4bit_mode_r && fx_fill_length_more_than_15) || 
+                                (!fx_2bit_polygon_filler_mode && fx_4bit_mode_r && fx_fill_length_more_than_7) ||
+                                ( fx_2bit_polygon_filler_mode && fx_pixel_pos_y_r[8]);
 
     end
 
@@ -339,14 +394,19 @@ module addr_data(
     always @* begin
         // vram_addr_0_next                 = vram_addr_0_r;
         // vram_addr_1_next                 = vram_addr_1_r;
+        // vram_addr_nib_0_next             = vram_addr_nib_0_r;
+        // vram_addr_nib_1_next             = vram_addr_nib_1_r;
         vram_addr_incr_0_next            = vram_addr_incr_0_r;
         vram_addr_incr_1_next            = vram_addr_incr_1_r;
+        vram_addr_nib_incr_0_next        = vram_addr_nib_incr_0_r;
+        vram_addr_nib_incr_1_next        = vram_addr_nib_incr_1_r;
         vram_addr_decr_0_next            = vram_addr_decr_0_r;
         vram_addr_decr_1_next            = vram_addr_decr_1_r;
         vram_data0_next                  = vram_data0_r;
         vram_data1_next                  = vram_data1_r;
         
         fx_addr1_mode_next               = fx_addr1_mode_r;
+        fx_4bit_mode_next                = fx_4bit_mode_r;
         fx_16bit_hop_next                = fx_16bit_hop_r;
         fx_mult_enabled_next             = fx_mult_enabled_r;
         fx_reset_accum_next              = 0;
@@ -354,12 +414,14 @@ module addr_data(
         fx_add_or_sub_next               = fx_add_or_sub_r;
         
         fx_tiledata_base_address_next    = fx_tiledata_base_address_r;
+        fx_2bit_polygon_pixels_next      = fx_2bit_polygon_pixels_r;
         
         fx_map_base_address_next         = fx_map_base_address_r;
         fx_apply_clip_next               = fx_apply_clip_r;
         
         fx_map_size_next                 = fx_map_size_r;
         fx_cache_byte_index_next         = fx_cache_byte_index_r;
+        fx_cache_nibble_index_next       = fx_cache_nibble_index_r;
         fx_cache_increment_mode_next     = fx_cache_increment_mode_r;
         fx_cache_fill_enabled_next       = fx_cache_fill_enabled_r;
 
@@ -375,6 +437,7 @@ module addr_data(
         fx_cache_write_enabled_next      = fx_cache_write_enabled_r;
         fx_transparency_enabled_next     = fx_transparency_enabled_r;
         fx_one_byte_cache_cycling_next   = fx_one_byte_cache_cycling_r;
+        fx_2bit_poke_mode_next           = fx_2bit_poke_mode_r;
         
         fx_use_result_as_tileindex_next  = fx_use_result_as_tileindex_r;
         fx_calculate_addr1_based_on_position_next = fx_calculate_addr1_based_on_position_r;
@@ -387,6 +450,8 @@ module addr_data(
         fx_pixel_position_needs_to_be_updated = 0;
 
         ib_addr_next                     = ib_addr_r;
+        ib_addr_nibble_next              = 0;
+        ib_4bit_mode_next                = 0;
         ib_transparency_enabled_next     = 0;
         ib_one_byte_cache_cycling_next   = 0;
         ib_cache_write_enabled_next      = 0;
@@ -424,11 +489,18 @@ module addr_data(
             fx_16bit_hop_start_index_next = write_data[1:0];  // We remember the lower two bits of the address that was set to addr1
         end
 
-        if (do_write && access_addr == 5'h00 && vram_addr_select) begin
+        if (do_write && access_addr == 5'h00 && vram_addr_select && fx_2bit_polygon_filler_mode) begin
+            // We turn on poke mode when ADDR1_LOW is set
+            fx_2bit_poke_mode_next = 1;
+            vram_addr_1_untouched_or_set_low = { vram_addr_1_r[7:2] , write_data[1:0] };
+        end else
+        if (do_write && access_addr == 5'h00 && vram_addr_select && !fx_2bit_polygon_filler_mode) begin
             vram_addr_1_untouched_or_set_low = write_data;
-        end else begin
+        end else 
+        begin
             vram_addr_1_untouched_or_set_low = vram_addr_1_r[7:0];
         end
+        
         if (do_write && access_addr == 5'h00 && !vram_addr_select) begin
             vram_addr_0_untouched_or_set_low = write_data;
         end else begin
@@ -448,17 +520,23 @@ module addr_data(
         
         if (do_write && access_addr == 5'h02 && vram_addr_select) begin
             vram_addr_1_untouched_or_set_bit16 = write_data[0];
+            vram_addr_1_untouched_or_set_nibble = write_data[1];
             vram_addr_incr_1_next = write_data[7:4];
             vram_addr_decr_1_next = write_data[3];
+            vram_addr_nib_incr_1_next = write_data[2];
         end else begin
             vram_addr_1_untouched_or_set_bit16 = vram_addr_1_r[16];
+            vram_addr_1_untouched_or_set_nibble = vram_addr_nib_1_r;
         end
         if (do_write && access_addr == 5'h02 && !vram_addr_select) begin
             vram_addr_0_untouched_or_set_bit16 = write_data[0];
+            vram_addr_0_untouched_or_set_nibble = write_data[1];
             vram_addr_incr_0_next = write_data[7:4];
             vram_addr_decr_0_next = write_data[3];
+            vram_addr_nib_incr_0_next = write_data[2];
         end else begin
             vram_addr_0_untouched_or_set_bit16 = vram_addr_0_r[16];
+            vram_addr_0_untouched_or_set_nibble = vram_addr_nib_0_r;
         end
 
         vram_addr_0_untouched_or_set = { vram_addr_0_untouched_or_set_bit16, vram_addr_0_untouched_or_set_high, vram_addr_0_untouched_or_set_low};
@@ -476,8 +554,10 @@ module addr_data(
 
         if (fx_vram_addr_0_needs_to_be_changed == ADDR0_INCR_0) begin
             vram_addr_0_next = vram_addr_0_incr_decr_0;
+            vram_addr_nib_0_next = vram_addr_nib_0_incr_decr_0;
         end else begin
             vram_addr_0_next = vram_addr_0_untouched_or_set;
+            vram_addr_nib_0_next = vram_addr_0_untouched_or_set_nibble;
         end
 
         //////////////////////////////////////////////////////////////////////////
@@ -501,9 +581,9 @@ module addr_data(
             fx_pixel_position_needs_to_be_updated = 1;
             fx_calculate_addr1_based_on_position_next = 1;
         end
-        // In polygon filler mode we increment the pixel positions when reading from or writing to DATA1
+        // In polygon filler mode (when not in poke mode) we increment the pixel positions when reading from or writing to DATA1
         // We also calculate the new ADDR1 after updating the pixel positions
-        if (do_read && access_addr == 5'h04 && fx_addr1_mode_r == MODE_POLY_FILL) begin
+        if (do_read && access_addr == 5'h04 && fx_addr1_mode_r == MODE_POLY_FILL && !fx_2bit_poke_mode_r) begin
             fx_pixel_position_needs_to_be_updated = 1;
             fx_calculate_addr1_based_on_position_next = 1;
         end
@@ -515,6 +595,18 @@ module addr_data(
         end
 
 
+        fx_nibble_to_be_loaded_into_cache = access_addr == 5'h03 ? (vram_addr_nib_0_r ? vram_data0_r[3:0] : vram_data0_r[7:4]) : (vram_addr_nib_1_r ? vram_data1_r[3:0] : vram_data1_r[7:4]);
+        case ({fx_cache_byte_index_r, fx_cache_nibble_index_r})
+            3'b000: fx_cache_filled_with_nibble = { ib_cache32_r[31:8],  fx_nibble_to_be_loaded_into_cache, ib_cache32_r[3:0] };
+            3'b001: fx_cache_filled_with_nibble = { ib_cache32_r[31:4],  fx_nibble_to_be_loaded_into_cache                    };
+            3'b010: fx_cache_filled_with_nibble = { ib_cache32_r[31:16], fx_nibble_to_be_loaded_into_cache, ib_cache32_r[11:0] };
+            3'b011: fx_cache_filled_with_nibble = { ib_cache32_r[31:12], fx_nibble_to_be_loaded_into_cache, ib_cache32_r[7:0] };
+            3'b100: fx_cache_filled_with_nibble = { ib_cache32_r[31:24], fx_nibble_to_be_loaded_into_cache, ib_cache32_r[19:0] };
+            3'b101: fx_cache_filled_with_nibble = { ib_cache32_r[31:20], fx_nibble_to_be_loaded_into_cache, ib_cache32_r[15:0] };
+            3'b110: fx_cache_filled_with_nibble = {                      fx_nibble_to_be_loaded_into_cache, ib_cache32_r[27:0] };
+            3'b111: fx_cache_filled_with_nibble = { ib_cache32_r[31:28], fx_nibble_to_be_loaded_into_cache, ib_cache32_r[23:0] };
+        endcase
+        
         fx_byte_to_be_loaded_into_cache = access_addr == 5'h03 ? vram_data0_r : vram_data1_r;
         case (fx_cache_byte_index_r)
             2'b00: fx_cache_filled_with_byte = { ib_cache32_r[31:8],  fx_byte_to_be_loaded_into_cache                    };
@@ -523,7 +615,10 @@ module addr_data(
             2'b11: fx_cache_filled_with_byte = {                      fx_byte_to_be_loaded_into_cache, ib_cache32_r[23:0] };
         endcase
 
-        if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04)) begin
+        if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04) && fx_4bit_mode_r) begin
+            // When cache is enabled, the nibble that has been read is put into the cache (at the correct position of the 32 bits)
+            ib_cache32_next = fx_cache_filled_with_nibble;
+        end else if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04) && !fx_4bit_mode_r) begin
             // When cache is enabled, the byte that has been read is put into the cache (at the correct position of the 32 bits)
             ib_cache32_next = fx_cache_filled_with_byte;
         end else begin
@@ -533,6 +628,7 @@ module addr_data(
 
         if (do_write && access_addr == 5'h0C && dc_select == 2) begin
             fx_cache_byte_index_next = write_data[3:2];
+            fx_cache_nibble_index_next = write_data[1];
         end else
         if (do_read && !fx_cache_fill_enabled_r && access_addr == 5'h03 && fx_addr1_mode_r == MODE_POLY_FILL && fx_one_byte_cache_cycling_r) begin
             // We also want to increment the cache byte index if one_byte_cache_cycling is turned on
@@ -543,29 +639,64 @@ module addr_data(
             end
         end else 
         if (do_read && fx_cache_fill_enabled_r && (access_addr == 5'h03 || access_addr == 5'h04)) begin
-            if (fx_cache_increment_mode_r) begin
-                fx_cache_byte_index_next[0] = !fx_cache_byte_index_r[0]; // loop: 0 -> 1 -> 0 ... or 2 -> 3 -> 2 ...
+            if(fx_4bit_mode_r) begin
+                // Note: we disable the second cache mode when in 4-bit mode, so we only do this:
+                // loop: 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 0 ...
+                fx_cache_byte_and_nibble_incremented = {fx_cache_byte_index_r, fx_cache_nibble_index_r } + 3'd1; 
+                fx_cache_byte_index_next = fx_cache_byte_and_nibble_incremented[2:1];  
+                fx_cache_nibble_index_next = fx_cache_byte_and_nibble_incremented[0];  
             end else begin
-                fx_cache_byte_index_next = fx_cache_byte_index_r + 2'd1;  // loop: 0 -> 1 -> 2 -> 3 -> 0 ...
+                if (fx_cache_increment_mode_r) begin
+                    fx_cache_byte_index_next[0] = !fx_cache_byte_index_r[0]; // loop: 0 -> 1 -> 0 ... or 2 -> 3 -> 2 ...
+                end else begin
+                    fx_cache_byte_index_next = fx_cache_byte_index_r + 2'd1;  // loop: 0 -> 1 -> 2 -> 3 -> 0 ...
+                end
             end
         end
 
         if ((do_write || do_read) && (access_addr == 5'h03 || access_addr == 5'h04)) begin
             ib_write_next  = do_write;
         end
-
+        
         if (do_write && (access_addr == 5'h03 || access_addr == 5'h04)) begin
             
-            ib_wrdata_next = write_data;
-            ib_addr_next = access_addr == 5'h03 ? vram_addr_0_r : vram_addr_1_r;
-            ib_do_access_next = 1;
+            // Note: we need to check for fx_addr1_mode_r here, since we could get an interrupt while we are in poke mode and the interrupt handler can turn off/change addr1 mode!
+            if(fx_2bit_poke_mode_r && fx_addr1_mode_r == MODE_POLY_FILL && access_addr == 5'h04) begin
+                case (write_data[7:6])
+                    2'b00: ib_wrdata_next = {                    ib_cache8[7:6], vram_data1_r[5:0] };
+                    2'b01: ib_wrdata_next = { vram_data1_r[7:6], ib_cache8[5:4], vram_data1_r[3:0] };
+                    2'b10: ib_wrdata_next = { vram_data1_r[7:4], ib_cache8[3:2], vram_data1_r[1:0] };
+                    2'b11: ib_wrdata_next = { vram_data1_r[7:2], ib_cache8[1:0] };
+
+                endcase
+                ib_addr_next = vram_addr_1_r;
+                ib_do_access_next = 1;
+
+                // This is the default for these:
+                // ib_addr_nibble_next = 0; // We temporarily do not use the nibble index
+                // ib_4bit_mode_next = 0;  // We temporarily turn off 4-bit mode
+                // ib_cache_write_enabled_next = 0; // We temporarily turn off cache writing
+                // ib_transparency_enabled_next = 0; // We temporarily turn off transparent writes
+                // ib_one_byte_cache_cycling_next = 0; // We temporarity turn off the use of cache byte cycling
                 
-            // Only when writing to *main* VRAM do we allow multibyte cache writes or transparancy
-            if (!is_audio_address && !is_palette_address && !is_sprite_attr_address) begin
-                ib_cache_write_enabled_next     = fx_cache_write_enabled_r;
-                ib_one_byte_cache_cycling_next  = fx_one_byte_cache_cycling_r;
-                ib_transparency_enabled_next    = fx_transparency_enabled_r;
-            end 
+                // Poke mode is turned off after writing to DATA1
+                fx_2bit_poke_mode_next = 0;
+                
+            end else begin
+                ib_wrdata_next = write_data;
+                ib_addr_next = access_addr == 5'h03 ? vram_addr_0_r : vram_addr_1_r;
+                ib_do_access_next = 1;
+                
+                // Only when writing to *main* VRAM do we allow multibyte cache writes or transparancy or nibble writes
+                if (!is_audio_address && !is_palette_address && !is_sprite_attr_address) begin
+                    ib_addr_nibble_next             = access_addr == 5'h03 ? vram_addr_nib_0_r : vram_addr_nib_1_r;
+                    ib_4bit_mode_next               = fx_4bit_mode_r;
+                    ib_cache_write_enabled_next     = fx_cache_write_enabled_r;
+                    ib_one_byte_cache_cycling_next  = fx_one_byte_cache_cycling_r;
+                    ib_transparency_enabled_next    = fx_transparency_enabled_r;
+                end 
+                
+            end
 
         end
 
@@ -579,11 +710,13 @@ module addr_data(
             fx_cache_fill_enabled_next = write_data[5];
             fx_one_byte_cache_cycling_next = write_data[4];
             fx_16bit_hop_next = write_data[3];
+            fx_4bit_mode_next = write_data[2];
             fx_addr1_mode_next = write_data[1:0];
         end
         if (do_write && access_addr == 5'h0A && dc_select == 2) begin
             fx_tiledata_base_address_next = write_data[7:2];
             fx_apply_clip_next = write_data[1];
+            fx_2bit_polygon_pixels_next = write_data[0];
         end 
         if (do_write && access_addr == 5'h0B && dc_select == 2) begin
             fx_map_base_address_next = write_data[7:2];
@@ -595,6 +728,7 @@ module addr_data(
             fx_add_or_sub_next = write_data[5];
             fx_mult_enabled_next = write_data[4];
             // fx_cache_byte_index_next is set above
+            // fx_cache_nibble_index_next is set above
             fx_cache_increment_mode_next = write_data[0];
         end 
         
@@ -723,14 +857,27 @@ module addr_data(
         end
         
         vram_addr_1_tileindex_lookup = {fx_map_base_address_r, 11'b0} + fx_tile_position_repeat;
-        vram_addr_1_tiledata_using_tilemap = {fx_tiledata_base_address_r, 11'b0} + {fx_tile_index_looked_up, fx_pixel_position_in_tile_y, fx_pixel_position_in_tile_x};
+        if (fx_4bit_mode_r) begin
+            vram_addr_1_tiledata_using_tilemap = {fx_tiledata_base_address_r, 11'b0} + {fx_tile_index_looked_up, fx_pixel_position_in_tile_y, fx_pixel_position_in_tile_x[2:1]};
+            vram_addr_nib_1_tiledata_using_tilemap = fx_pixel_position_in_tile_x[0];
+        end else begin
+            vram_addr_1_tiledata_using_tilemap = {fx_tiledata_base_address_r, 11'b0} + {fx_tile_index_looked_up, fx_pixel_position_in_tile_y, fx_pixel_position_in_tile_x};
+            vram_addr_nib_1_tiledata_using_tilemap = 0;
+        end
         
         //////////////////////////////////////////////////////////////////////////
         // Start of fill line calculation
         //////////////////////////////////////////////////////////////////////////
 
-        // Note: we are sign extending the x pixel position here, since it might be a negative number
-        vram_addr_1_start_of_horizontal_fill_line = vram_addr_0_r + { {6{fx_pixel_pos_x_r[19]}}, fx_pixel_pos_x_r[19:9]};
+        if (fx_4bit_mode_r) begin
+            // Note: we are sign extending the x pixel position here, since it might be a negative number
+            vram_addr_1_start_of_horizontal_fill_line = vram_addr_0_r + { {7{fx_pixel_pos_x_r[19]}}, fx_pixel_pos_x_r[19:10]};
+            vram_addr_nib_1_start_of_horizontal_fill_line = fx_pixel_pos_x_r[9];
+        end else begin
+            // Note: we are sign extending the x pixel position here, since it might be a negative number
+            vram_addr_1_start_of_horizontal_fill_line = vram_addr_0_r + { {6{fx_pixel_pos_x_r[19]}}, fx_pixel_pos_x_r[19:9]};
+            vram_addr_nib_1_start_of_horizontal_fill_line = 0;
+        end
 
         //////////////////////////////////////////////////////////////////////////
         // ADDR1 control logic and assignment
@@ -744,7 +891,7 @@ module addr_data(
         end else if (fx_calculate_addr1_based_on_tileindex_r) begin
             fx_vram_addr_1_needs_to_be_changed = ADDR1_TILEDATA; // Addr_1 needs to be set with tilebase + tileposition based on rdata
             fx_calculate_addr1_based_on_tileindex_next = 0;
-        end else if (do_write && access_addr == 5'h04 && fx_addr1_mode_r == MODE_POLY_FILL) begin
+        end else if (do_write && access_addr == 5'h04 && fx_addr1_mode_r == MODE_POLY_FILL && !fx_2bit_poke_mode_r) begin
             fx_vram_addr_1_needs_to_be_changed = ADDR1_INCR_1;  // addr_1 needs to be set with vram_addr_1_incr_decr_1
         end else if ((do_write || do_read) && access_addr == 5'h04 && fx_addr1_mode_r == MODE_NORMAL) begin
             // in normal addr1-mode we do a "normal" increment
@@ -766,27 +913,33 @@ module addr_data(
             ADDR1_INCR_1: begin
                 // We increment addr1 with its own incrementer 
                 vram_addr_1_next = vram_addr_1_incr_decr_1;
+                vram_addr_nib_1_next = vram_addr_nib_1_incr_decr_1;
             end
             ADDR1_INCR_1_AND_0: begin
                 // We increment addr1 with both its own incrementer as well as the incrementer of addr0
                 vram_addr_1_next = vram_addr_1_incr_decr_10;
+                vram_addr_nib_1_next = vram_addr_nib_1_incr_decr_1;
             end
             ADDR1_TILEDATA: begin
                 // We use the tile index we just looked up from the tilemap
                 vram_addr_1_next = vram_addr_1_tiledata_using_tilemap;
+                vram_addr_nib_1_next = vram_addr_nib_1_tiledata_using_tilemap;
             end
             ADDR1_MAP_LOOKUP: begin
                 // We set the address to the lookup place in the tile map (in order to retrieve the tileindex in the tile map)
                 vram_addr_1_next = vram_addr_1_tileindex_lookup;
+                vram_addr_nib_1_next = 0;
                 fx_use_result_as_tileindex_next = 1;
             end
             ADDR1_ADDR0_X1: begin 
                 // We set the address with ADDR0 + x pixel position: this is the new starting position on the left side of the horizontal fill line
                 vram_addr_1_next = vram_addr_1_start_of_horizontal_fill_line;
+                vram_addr_nib_1_next = vram_addr_nib_1_start_of_horizontal_fill_line;
             end
             default: begin  // ADDR1_UNTOUCHED, ADDR1_SET (and the unused value)
                 // We leave addr1 unchanged, unless just externally/explcitly set
                 vram_addr_1_next = vram_addr_1_untouched_or_set;
+                vram_addr_nib_1_next = vram_addr_1_untouched_or_set_nibble;
             end
         endcase
 
@@ -818,14 +971,19 @@ module addr_data(
         if (reset) begin
             vram_addr_0_r                 <= 0;
             vram_addr_1_r                 <= 0;
+            vram_addr_nib_0_r             <= 0;
+            vram_addr_nib_1_r             <= 0;
             vram_addr_incr_0_r            <= 0;
             vram_addr_incr_1_r            <= 0;
+            vram_addr_nib_incr_0_r        <= 0;
+            vram_addr_nib_incr_1_r        <= 0;
             vram_addr_decr_0_r            <= 0;
             vram_addr_decr_1_r            <= 0;
             vram_data0_r                  <= 0;
             vram_data1_r                  <= 0;
 
             fx_addr1_mode_r               <= 0;
+            fx_4bit_mode_r                <= 0;
             fx_16bit_hop_r                <= 0;
             fx_mult_enabled_r             <= 0;
             fx_reset_accum_r                <= 0;
@@ -833,6 +991,7 @@ module addr_data(
             fx_add_or_sub_r               <= 0;
         
             fx_tiledata_base_address_r    <= 0;
+            fx_2bit_polygon_pixels_r      <= 0;
             fx_map_base_address_r         <= 0;
             fx_apply_clip_r               <= 0;
             
@@ -840,6 +999,7 @@ module addr_data(
             fx_cache_fill_enabled_r       <= 0;
             fx_cache_increment_mode_r     <= 0;
             fx_cache_byte_index_r         <= 0;
+            fx_cache_nibble_index_r       <= 0;
             
             fx_pixel_pos_x_r              <= 20'd256; // half a pixel
             fx_pixel_pos_y_r              <= 20'd256; // half a pixel
@@ -853,6 +1013,7 @@ module addr_data(
             fx_cache_write_enabled_r      <= 0;
             fx_transparency_enabled_r     <= 0;
             fx_one_byte_cache_cycling_r   <= 0;
+            fx_2bit_poke_mode_r           <= 0;
             
             fx_use_result_as_tileindex_r  <= 0;
             fx_calculate_addr1_based_on_position_r <= 0;
@@ -861,6 +1022,8 @@ module addr_data(
             fx_16bit_hop_start_index_r    <= 0;
 
             ib_addr_r                     <= 0;
+            ib_addr_nibble_r              <= 0;
+            ib_4bit_mode_r                <= 0;
             ib_cache_write_enabled_r      <= 0;
             ib_transparency_enabled_r     <= 0;
             ib_one_byte_cache_cycling_r   <= 0;
@@ -878,14 +1041,19 @@ module addr_data(
         end else begin
             vram_addr_0_r                 <= vram_addr_0_next;
             vram_addr_1_r                 <= vram_addr_1_next;
+            vram_addr_nib_0_r             <= vram_addr_nib_0_next;
+            vram_addr_nib_1_r             <= vram_addr_nib_1_next;
             vram_addr_incr_0_r            <= vram_addr_incr_0_next;
             vram_addr_incr_1_r            <= vram_addr_incr_1_next;
+            vram_addr_nib_incr_0_r        <= vram_addr_nib_incr_0_next;
+            vram_addr_nib_incr_1_r        <= vram_addr_nib_incr_1_next;
             vram_addr_decr_0_r            <= vram_addr_decr_0_next;
             vram_addr_decr_1_r            <= vram_addr_decr_1_next;
             vram_data0_r                  <= vram_data0_next;
             vram_data1_r                  <= vram_data1_next;
 
             fx_addr1_mode_r               <= fx_addr1_mode_next;
+            fx_4bit_mode_r                <= fx_4bit_mode_next;
             fx_16bit_hop_r                <= fx_16bit_hop_next;
             fx_mult_enabled_r             <= fx_mult_enabled_next;
             fx_reset_accum_r              <= fx_reset_accum_next;
@@ -893,6 +1061,7 @@ module addr_data(
             fx_add_or_sub_r               <= fx_add_or_sub_next;
             
             fx_tiledata_base_address_r    <= fx_tiledata_base_address_next;
+            fx_2bit_polygon_pixels_r      <= fx_2bit_polygon_pixels_next;
             fx_map_base_address_r         <= fx_map_base_address_next;
             fx_apply_clip_r               <= fx_apply_clip_next;
             
@@ -900,6 +1069,7 @@ module addr_data(
             fx_cache_fill_enabled_r       <= fx_cache_fill_enabled_next;
             fx_cache_increment_mode_r     <= fx_cache_increment_mode_next;
             fx_cache_byte_index_r         <= fx_cache_byte_index_next;
+            fx_cache_nibble_index_r       <= fx_cache_nibble_index_next;
             
             fx_pixel_pos_x_r              <= fx_pixel_pos_x_next;
             fx_pixel_pos_y_r              <= fx_pixel_pos_y_next;
@@ -913,6 +1083,7 @@ module addr_data(
             fx_cache_write_enabled_r      <= fx_cache_write_enabled_next;
             fx_transparency_enabled_r     <= fx_transparency_enabled_next;
             fx_one_byte_cache_cycling_r   <= fx_one_byte_cache_cycling_next;
+            fx_2bit_poke_mode_r           <= fx_2bit_poke_mode_next;
             
             fx_use_result_as_tileindex_r  <= fx_use_result_as_tileindex_next;
             fx_calculate_addr1_based_on_position_r <= fx_calculate_addr1_based_on_position_next;
@@ -921,6 +1092,8 @@ module addr_data(
             fx_16bit_hop_start_index_r    <= fx_16bit_hop_start_index_next;
 
             ib_addr_r                     <= ib_addr_next;
+            ib_addr_nibble_r              <= ib_addr_nibble_next;
+            ib_4bit_mode_r                <= ib_4bit_mode_next;
             ib_cache_write_enabled_r      <= ib_cache_write_enabled_next;
             ib_transparency_enabled_r     <= ib_transparency_enabled_next;
             ib_one_byte_cache_cycling_r   <= ib_one_byte_cache_cycling_next;


### PR DESCRIPTION
In this PR the 4-bit and 2-bit modes are added to the fx branch.

It does the following things:

- adds the general nibble incrementer/decrementer
- adds 4-bit mode for affine helper
- adds 4-bit mode for line drawing
- adds 4-bit mode for polygon filler
- adds 2-bit polygon pixel mode for polygon filler (including 2bit poke mode) 
- allows for writing a single nibble to VRAM
- adds nibble cache filling and tranparency

This PR completes the FX update.