### PR TITLE
For L0 and L1: palette offset bit 7 is OR-ed with T256C (in 2bpp, 4bpp and 8bpp mode)

### DIFF
--- a/fpga/source/graphics/layer_renderer.v
+++ b/fpga/source/graphics/layer_renderer.v
@@ -475,7 +475,7 @@ module layer_renderer(
     always @* begin
         cur_pixel_color[3:0] = tmp_pixel_color[3:0];
         if (color_depth != 0 && tmp_pixel_color[7:4] == 0 && tmp_pixel_color[3:0] != 0) begin
-            cur_pixel_color[7:4] = render_mapdata_r[7:4];
+            cur_pixel_color[7:4] = {render_mapdata_r[7] | attr_mode, render_mapdata_r[6:4] };
         end else begin
             cur_pixel_color[7:4] = tmp_pixel_color[7:4];
         end

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -204,7 +204,7 @@ module top(
                 6'h0: rddata = dc_border_color_r;
                 6'h1: rddata = dc_active_vstop_r[8:1];
                 6'h5: rddata = fx_fill_length_high;
-                default: rddata = 8'h01;
+                default: rddata = 8'h02;
             endcase
         end
 


### PR DESCRIPTION
For L0 and L1: palette offset bit 7 is OR-ed with T256C (in 2bpp, 4bpp and 8bpp mode)

This allows for certain effects like creating "underwater effects": at a specific line interrupt this bit is can be set which switches all colors in all tiles to a different palette (like monochrome blue-ish colors). More usages can be thought of. These include (fast global or screenbar) color changes for
- twinklng of stars
- alarms
- explosions 
- laser beam
- water / sewage

Its a very simple change with little cost.

LUT cost: LUT usage goes from 5012 to 5015, so +3 LUTs. So very minimal.
(Place and Routing) Timing analysis shows no issues.

This idea was originally suggested by fearlabsaudio in Discord. See here for discussion (scroll up for history):
https://discord.com/channels/547559626024157184/549247967945687071/1175531621760368660

MooingLemur has implemented this feature in the emulator.

Here is an example of the water effect running on this version of the emulator:
https://github.com/X16Community/vera-module/assets/17767704/36edffa9-395b-4a1a-a94f-62ba299c75e4

This was also tested on real hardware:
https://discord.com/channels/547559626024157184/549247967945687071/1175565800376119366

After running several programs there doesnt seem to be anything broken.
https://discord.com/channels/547559626024157184/549247967945687071/1175682555186520156

---

Several other kinds of logic have been proposed, but this implementation is both simple and cheap (cost is actually zero LUTs for the logical change and 3 LUTs for changing the version number of VERA):
- using XOR instead of OR is more restrictive to the developer (color indexes you dont want to change get changed, so you cant use them for other purposes)
- the initial idea was to *set* the palette offset to a specific value (e.g. $F0) but that turned out to be quite expensive (25 LUTs)
- restricting this effect to tilemode only was also somewhat more costly (10 LUTs) but having the side effect of the bitmap palette offset being changed (which is not needed since you can already manipulate it with on byte setting) wasnt problematic enough to require this extra cost

In all it seems like a nice little feature that is basicly free. It fits in the spirit of VERA and feels like a good addition to it.
