### PR TITLE
Add an ability to replay and loop FIFO data

### DIFF
--- a/fpga/source/audio/audio.v
+++ b/fpga/source/audio/audio.v
@@ -17,6 +17,8 @@ module audio(
 
     // Audio FIFO interface
     input  wire        fifo_reset,
+    input  wire        fifo_restart,
+    input  wire        fifo_loop,
     input  wire  [7:0] fifo_wrdata,
     input  wire        fifo_write,
     output wire        fifo_full,
@@ -70,6 +72,8 @@ module audio(
 
         // Audio FIFO interface
         .fifo_reset(fifo_reset),
+        .fifo_restart(fifo_restart),
+        .fifo_loop(fifo_loop),
         .fifo_wrdata(fifo_wrdata),
         .fifo_write(fifo_write),
         .fifo_full(fifo_full),

--- a/fpga/source/audio/audio_fifo.v
+++ b/fpga/source/audio/audio_fifo.v
@@ -6,7 +6,8 @@ module audio_fifo(
 
     input  wire [7:0] wrdata,
     input  wire       wr_en,
-
+    input  wire       rd_rst,
+    
     output reg  [7:0] rddata,
     input  wire       rd_en,
     
@@ -42,6 +43,10 @@ module audio_fifo(
             if (rd_en && !empty) begin
                 rddata <= mem_r[rdidx_r];
                 rdidx_r <= rdidx_next;
+            end
+
+            if (rd_rst) begin
+                rdidx_r <= 0;
             end
         end
     end

--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -14,6 +14,8 @@ module pcm(
 
     // Audio FIFO interface
     input  wire        fifo_reset,
+    input  wire        fifo_restart,
+    input  wire        fifo_loop,
     input  wire  [7:0] fifo_wrdata,
     input  wire        fifo_write,
     output wire        fifo_full,
@@ -42,6 +44,7 @@ module pcm(
 
         .rddata(fifo_rddata),
         .rd_en(fifo_read),
+        .rd_rst(fifo_restart_r),
         
         .empty(fifo_empty),
         .almost_empty(fifo_almost_empty),
@@ -82,6 +85,8 @@ module pcm(
         FETCH_R_15_8 = 3'd4,
         DONE         = 3'd5;
 
+    reg        fifo_restart_r, fifo_restart_next;
+    reg        fifo_restart_l_r, fifo_restart_l_next;
     reg  [2:0] state_r, state_next;
     reg [15:0] left_sample_r,  left_sample_next;
     reg [15:0] right_sample_r, right_sample_next;
@@ -93,25 +98,32 @@ module pcm(
     wire [15:0] right_sample = mode_16bit ? right_sample_r : {right_sample_r[7:0], 8'b0};
 
     always @* begin
-        state_next        = state_r;
-        left_sample_next  = left_sample_r;
-        right_sample_next = right_sample_r;
-        left_output_next  = left_output_r;
-        right_output_next = right_output_r;
-        fifo_read         = 0;
-
+        state_next          = state_r;
+        left_sample_next    = left_sample_r;
+        right_sample_next   = right_sample_r;
+        left_output_next    = left_output_r;
+        right_output_next   = right_output_r;
+        fifo_read           = 0;
+        fifo_restart_l_next = fifo_restart_l_r | fifo_restart;
+        fifo_restart_next   = 0;
+        
         case (state_r)
             IDLE: begin
-                if (fifo_empty) begin
-                    left_output_next  = 0;
-                    right_output_next = 0;
+                if (fifo_restart_l_r) begin
+                    fifo_restart_next   = 1;
+                    fifo_restart_l_next = 0;
                 end
 
-                if (new_sample && !fifo_empty) begin
-                    left_sample_next  = 0;
-                    right_sample_next = 0;
-                    state_next        = FETCH_L_7_0;
-                    fifo_read         = 1;
+                if (new_sample) begin
+                    if (fifo_empty) begin
+                        left_output_next  = 0;
+                        right_output_next = 0;
+                    end else begin
+                        left_sample_next  = 0;
+                        right_sample_next = 0;
+                        state_next        = FETCH_L_7_0;
+                        fifo_read         = 1;
+                    end
                 end
             end
 
@@ -162,6 +174,9 @@ module pcm(
             end
         endcase
 
+        if (fifo_empty && fifo_loop) begin
+            fifo_restart_next = 1;
+        end
         if (state_r != DONE && fifo_empty) begin
             fifo_read  = 0;
             state_next = IDLE;
@@ -171,18 +186,22 @@ module pcm(
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            state_r        <= IDLE;
-            left_sample_r  <= 0;
-            right_sample_r <= 0;
-            left_output_r  <= 0;
-            right_output_r <= 0;
-        
+            state_r          <= IDLE;
+            left_sample_r    <= 0;
+            right_sample_r   <= 0;
+            left_output_r    <= 0;
+            right_output_r   <= 0;
+            fifo_restart_r   <= 0;
+            fifo_restart_l_r <= 0;
+            
         end else begin
             state_r        <= state_next;
             left_sample_r  <= left_sample_next;
             right_sample_r <= right_sample_next;
             left_output_r  <= left_output_next;
             right_output_r <= right_output_next;
+            fifo_restart_r <= fifo_restart_next;
+            fifo_restart_l_r <= fifo_restart_l_next;
         end
     end
 

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -137,6 +137,8 @@ module top(
     reg        audio_mode_stereo_r,           audio_mode_stereo_next;
     reg        audio_mode_16bit_r,            audio_mode_16bit_next;
     reg        audio_fifo_reset_r,            audio_fifo_reset_next;
+    reg        audio_fifo_restart_r,          audio_fifo_restart_next;
+    reg        audio_fifo_loop_r,             audio_fifo_loop_next;
     wire       audio_fifo_full;
     reg  [3:0] audio_pcm_volume_r,            audio_pcm_volume_next;
     reg  [7:0] audio_fifo_wrdata_r,           audio_fifo_wrdata_next;
@@ -316,6 +318,8 @@ module top(
         audio_mode_stereo_next           = audio_mode_stereo_r;
         audio_mode_16bit_next            = audio_mode_16bit_r;
         audio_fifo_reset_next            = 0;
+        audio_fifo_restart_next          = 0;
+        audio_fifo_loop_next             = audio_fifo_loop_r;
         audio_pcm_volume_next            = audio_pcm_volume_r;
         audio_fifo_wrdata_next           = audio_fifo_wrdata_r;
         audio_fifo_write_next            = 0;
@@ -469,7 +473,9 @@ module top(
         end
 
         if (do_write && access_addr == 5'h1B) begin
-            audio_fifo_reset_next       = write_data[7];
+            audio_fifo_reset_next       = write_data[7:6] == 2'b10;
+            audio_fifo_restart_next     = write_data[6];
+            audio_fifo_loop_next        = write_data[7:6] == 2'b11;
             audio_mode_16bit_next       = write_data[5];
             audio_mode_stereo_next      = write_data[4];
             audio_pcm_volume_next       = write_data[3:0];
@@ -539,6 +545,8 @@ module top(
             audio_mode_stereo_r           <= 0;
             audio_mode_16bit_r            <= 0;
             audio_fifo_reset_r            <= 0;
+            audio_fifo_restart_r          <= 0;
+            audio_fifo_loop_r             <= 0;
             audio_pcm_volume_r            <= 0;
             audio_fifo_wrdata_r           <= 0;
             audio_fifo_write_r            <= 0;
@@ -597,6 +605,8 @@ module top(
             audio_mode_stereo_r           <= audio_mode_stereo_next;
             audio_mode_16bit_r            <= audio_mode_16bit_next;
             audio_fifo_reset_r            <= audio_fifo_reset_next;
+            audio_fifo_restart_r          <= audio_fifo_restart_next;
+            audio_fifo_loop_r             <= audio_fifo_loop_next;
             audio_pcm_volume_r            <= audio_pcm_volume_next;
             audio_fifo_wrdata_r           <= audio_fifo_wrdata_next;
             audio_fifo_write_r            <= audio_fifo_write_next;
@@ -1177,6 +1187,8 @@ module top(
 
         // Audio FIFO interface
         .fifo_reset(audio_fifo_reset_r),
+        .fifo_restart(audio_fifo_restart_r),
+        .fifo_loop(audio_fifo_loop_r),
         .fifo_wrdata(audio_fifo_wrdata_r),
         .fifo_write(audio_fifo_write_r),
         .fifo_full(audio_fifo_full),


### PR DESCRIPTION
This is a re-submission of a PR created by @akumanatt. See #11. The changes Natt made we simply re-applied to the (now refactored due to the FX merge) main branch. In fact only the changes to top.v had to be adjusted. This was done **by hand** as was therefore prone to human error.

**IMPORTANT NOTE: the submitter (JeffreyH) did NOT create this change and does (as of yet) NOT know whether it would work in real HW!**

Orignal text from @akumanatt (Jun 10, 2023):

> This update adds 2 write bits to VERA registers: AUDIO_CTRL bit 6 and AUDIO_RATE bit 7.
>
>Writing 1 to AUDIO_CTRL bit 6 will only reset FIFO's read position to 0. This allows a sample data in the buffer to be replayed any time without refilling it again. AUDIO_RATE bit 7 set will enable looped playback where the read position is automatically reset to 0 if the buffer becomes empty in the next sample. Although an AUDIO_RATE value of 128 will still play at the maximum rate without looping.
>
>Note that a position of 0 here means an internal buffer's address. Which means a FIFO reset (write 1 to AUDIO_CTRL bit 7) is required in order to reset the write position to 0 too before uploading a sample data and make these methods above play correctly.

Comment/review by JeffreyH (Jun 16, 2023)

>I have tried to include these changes into the fx-branch. After doing so I found out a few things:
>
>The change raised the LUT count by 46, which is more than you would expect.
>Attempts to reduce the LUT-count were partially successful (down to 16 LUTs) but resulted in a different way of interfacing with the looping/reset settings, which may be undesired.
>The change resets rdidx_r (in audio_fifo.v) when a restart of the read position is triggered. However, the state_r (in pcm.v) is not reset. This means that the fifo-reading might be in an intermediate state (say: 8-bit stereo, and only the left byte has been read, but not the right one) when the fifo read position is reset. This may cause strange/unwanted effects.
>It is probably required to wait for the state to be DONE or IDLE before executing a read-reset. This means some logic needs to be added and/or adjusted.
>It is probably prudent to re-think how the logic should work and how the interface should work for this feature. Then implement that. Then LUT-optimization (and review) can be performed.
>
>JeffreyH

Comment by @akumanatt (12 Aug, 2023):
>I updated the loop method to be a combination of AUDIO_CTRL bits 6-7 now. Also, I made it reset only in IDLE state.