### PR TITLE
Increase audio mixing resolution 2

### DIFF
--- a/fpga/source/audio/audio.v
+++ b/fpga/source/audio/audio.v
@@ -29,11 +29,11 @@ module audio(
     output wire        i2s_data);
 
     wire        next_sample;
-    wire [15:0] psg_left;
-    wire [15:0] psg_right;
+    wire [18:0] psg_left;
+    wire [18:0] psg_right;
 
-    wire [15:0] pcm_left;
-    wire [15:0] pcm_right;
+    wire [22:0] pcm_left;
+    wire [22:0] pcm_right;
 
     //////////////////////////////////////////////////////////////////////////
     // Programmable Sound Generator
@@ -84,16 +84,13 @@ module audio(
     // I2S DAC interface
     //////////////////////////////////////////////////////////////////////////
 
-    wire [16:0] psg_l = {psg_left[15], psg_left};
-    wire [16:0] psg_r = {psg_right[15], psg_right};
-    wire [16:0] pcm_l = {pcm_left[15], pcm_left};
-    wire [16:0] pcm_r = {pcm_right[15], pcm_right};
+    wire [23:0] psg_l = {psg_left[18], psg_left, 4'b0};
+    wire [23:0] psg_r = {psg_right[18], psg_right, 4'b0};
+    wire [23:0] pcm_l = {pcm_left[22], pcm_left};
+    wire [23:0] pcm_r = {pcm_right[22], pcm_right};
 
-    wire [16:0] mix_l = psg_l + pcm_l;
-    wire [16:0] mix_r = psg_r + pcm_r;
-
-    wire [23:0] left_data = {mix_l, 7'b0};
-    wire [23:0] right_data = {mix_r, 7'b0};
+    wire [23:0] left_data = psg_l + pcm_l;
+    wire [23:0] right_data = psg_r + pcm_r;
 
     dacif dacif(
         .rst(rst),

--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -21,8 +21,8 @@ module pcm(
     output wire        fifo_empty,
 
     // Audio output
-    output wire [15:0] left_audio,
-    output wire [15:0] right_audio) /* synthesis syn_hier = "hard" */;
+    output wire [22:0] left_audio,
+    output wire [22:0] right_audio) /* synthesis syn_hier = "hard" */;
 
 
     //////////////////////////////////////////////////////////////////////////
@@ -191,34 +191,34 @@ module pcm(
     //////////////////////////////////////////////////////////////////////////
 
     // Logarithmic volume conversion (2.26dB per step)
-    reg signed [7:0] volume_log;
+    reg signed [8:0] volume_log;
     always @* case (volume)
-        4'd0:  volume_log = 8'd0;
-        4'd1:  volume_log = 8'd1;
-        4'd2:  volume_log = 8'd2;
-        4'd3:  volume_log = 8'd3;
-        4'd4:  volume_log = 8'd4;
-        4'd5:  volume_log = 8'd5;
-        4'd6:  volume_log = 8'd6;
-        4'd7:  volume_log = 8'd8;
-        4'd8:  volume_log = 8'd11;
-        4'd9:  volume_log = 8'd14;
-        4'd10: volume_log = 8'd18;
-        4'd11: volume_log = 8'd23;
-        4'd12: volume_log = 8'd30;
-        4'd13: volume_log = 8'd38;
-        4'd14: volume_log = 8'd49;
-        4'd15: volume_log = 8'd64;
+        4'd0:  volume_log = 9'd0;
+        4'd1:  volume_log = 9'd2;
+        4'd2:  volume_log = 9'd4;
+        4'd3:  volume_log = 9'd6;
+        4'd4:  volume_log = 9'd8;
+        4'd5:  volume_log = 9'd10;
+        4'd6:  volume_log = 9'd12;
+        4'd7:  volume_log = 9'd16;
+        4'd8:  volume_log = 9'd21;
+        4'd9:  volume_log = 9'd27;
+        4'd10: volume_log = 9'd35;
+        4'd11: volume_log = 9'd45;
+        4'd12: volume_log = 9'd59;
+        4'd13: volume_log = 9'd76;
+        4'd14: volume_log = 9'd99;
+        4'd15: volume_log = 9'd128;
     endcase
 
-    reg signed [21:0] left_scaled_r, right_scaled_r;
+    reg signed [22:0] left_scaled_r, right_scaled_r;
 
     always @(posedge clk) begin
         left_scaled_r  <= left_output_r  * volume_log;
         right_scaled_r <= right_output_r * volume_log;
     end
 
-    assign left_audio  = left_scaled_r[21:6];
-    assign right_audio = right_scaled_r[21:6];
+    assign left_audio  = left_scaled_r;
+    assign right_audio = right_scaled_r;
 
 endmodule

--- a/fpga/source/audio/psg.v
+++ b/fpga/source/audio/psg.v
@@ -12,8 +12,8 @@ module psg(
     input  wire        next_sample,
 
     // Audio output
-    output wire [15:0] left_audio,
-    output wire [15:0] right_audio) /* synthesis syn_hier = "hard" */;
+    output wire [18:0] left_audio,
+    output wire [18:0] right_audio) /* synthesis syn_hier = "hard" */;
 
 
     //////////////////////////////////////////////////////////////////////////
@@ -146,8 +146,8 @@ module psg(
     //////////////////////////////////////////////////////////////////////////
     // Audio generator state machine
     //////////////////////////////////////////////////////////////////////////
-    reg signed [15:0] left_sample_r, right_sample_r;
-    reg signed [15:0] left_accum_r,  right_accum_r;
+    reg signed [18:0] left_sample_r, right_sample_r;
+    reg signed [18:0] left_accum_r,  right_accum_r;
 
     parameter
         IDLE     = 2'b00,
@@ -198,8 +198,8 @@ module psg(
                 end
 
                 CALC_CH: begin
-                    if (cur_left_en)  left_accum_r  <= left_accum_r  + scaled_signal[14:3];
-                    if (cur_right_en) right_accum_r <= right_accum_r + scaled_signal[14:3];
+                    if (cur_left_en)  left_accum_r  <= left_accum_r  + scaled_signal;
+                    if (cur_right_en) right_accum_r <= right_accum_r + scaled_signal;
 
                     working_data_wridx_r <= cur_channel_r;
                     working_data_wren_r  <= 1;

--- a/fpga/source/audio/psg.v
+++ b/fpga/source/audio/psg.v
@@ -80,7 +80,7 @@ module psg(
             4'd10:   cur_volume_base = 9'd482;
             default: cur_volume_base = 9'd511;
         endcase
-        cur_volume_log = cur_volume_base >> cur_volume_shift[4:2];
+        cur_volume_log = (cur_volume == 6'd0) ? 9'd0 : (cur_volume_base >> cur_volume_shift[4:2]);
     end
 
     //////////////////////////////////////////////////////////////////////////

--- a/fpga/source/audio/psg.v
+++ b/fpga/source/audio/psg.v
@@ -80,7 +80,12 @@ module psg(
             4'd10:   cur_volume_base = 9'd482;
             default: cur_volume_base = 9'd511;
         endcase
-        cur_volume_log = (cur_volume == 6'd0) ? 9'd0 : (cur_volume_base >> cur_volume_shift[4:2]);
+        case (cur_volume)
+            6'd0:    cur_volume_log = 9'd0;
+            6'd1:    cur_volume_log = 9'd13;
+            6'd2:    cur_volume_log = 9'd14;
+            default: cur_volume_log = cur_volume_base >> cur_volume_shift[4:2];
+        endcase
     end
 
     //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This commit is an optional follow-up to PR #22. This increases PSG and PCM mixing to 23-bit each, making use of a full serial output range. The PCM volume table resolution is also increased by 1 bit.