### PR TITLE
FIX for issue that hflipping 8-pixel-wide 2bpp tiles didnt work

### DIFF
--- a/fpga/source/graphics/layer_renderer.v
+++ b/fpga/source/graphics/layer_renderer.v
@@ -332,6 +332,9 @@ module layer_renderer(
     reg [4:0] xcnt_r, xcnt_next;
 
     wire [3:0] hflipped_xcnt = render_mapdata_r[2] ? ~xcnt_r[3:0] : xcnt_r[3:0];
+	// For 2bpp 8-pixels-wide tile mode we dont want bit3 of hflipped_xcnt to be 1 (but we do when its 2bpp 16-pixels-wide tile mode or 2bpp bitmap mode)
+	// So we do an AND NOT with the lowest bit of lines_per_word_minus1 (which is only a 1 for 8 pixel wide tiled mode, for 2bpp)
+    wire [3:0] hflipped_xcnt_2bpp = {hflipped_xcnt[3] &(~lines_per_word_minus1[0]), hflipped_xcnt[2:0]};
 
     // Select current pixel for 1bpp modes
     reg cur_pixel_data_1bpp;
@@ -379,7 +382,7 @@ module layer_renderer(
 
     // Select current pixel for 2bpp modes
     reg [1:0] cur_pixel_data_2bpp;
-    always @* case (hflipped_xcnt[3:0])
+    always @* case (hflipped_xcnt_2bpp[3:0])
         // Byte 0
         4'd0:  cur_pixel_data_2bpp = render_data_r[7:6];
         4'd1:  cur_pixel_data_2bpp = render_data_r[5:4];

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -204,7 +204,7 @@ module top(
                 6'h0: rddata = dc_border_color_r;
                 6'h1: rddata = dc_active_vstop_r[8:1];
                 6'h5: rddata = fx_fill_length_high;
-                default: rddata = 8'h02;
+                default: rddata = 8'h03;
             endcase
         end
 


### PR DESCRIPTION
There is a bug in the layer renderer that makes 8-pixel-wide 2bpp tiles dissapear when trying to horizontally flip it.

As it turns out this is an old bug that has been in there since the beginning.

The bug has been reproduced on real hardware (for 0.3.1 and for 0.3.2):
![image](https://github.com/X16Community/vera-module/assets/17767704/9b5f2111-1699-40c3-977d-269739513aa7)
The hflipped arrows are not visible.
When run on the emulator it looks like this (which is correct):
![image](https://github.com/X16Community/vera-module/assets/17767704/71dfd440-e2c1-4e79-8cd0-98444120d6a3)

When looking at the verilog it became clear that the value for hflipped_xcnt was incorrect in the case of 2bpp 8-pixel-wide tiles: when flipped the value of xcnt_r was negated which resulted in hflipped_xcnt becoming >= 8. This is problematic since render_data_r[31:16] were zeroes (in this specific case).

The solution was to create a 2bpp-specific value for hflipped_xcnt named hflipped_xcnt_2bpp. This one makes sure that bit3 is set to 0 in this specific situation.

The result is a working 2bpp 8-pixel-wide hflip:

![image](https://github.com/X16Community/vera-module/assets/17767704/31b23947-083c-4b30-9421-deb247df8841)

The LUT-cost is 9 LUTs.

This bitsteam still has to be tested more thouroughly. Most notably other layer modes/color depths.

Link to discord discussion:

https://discord.com/channels/547559626024157184/549247967945687071/1196902079189504050
