### PR TITLE
Fix back to back write issue

### DIFF
--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -239,13 +239,15 @@ module top(
     // Capture address / write-data at end of write cycle
     reg [4:0] rdaddr_r;
     reg [4:0] wraddr_r;
+    reg [4:0] wraddr_hold_r;
     reg [7:0] wrdata_r;
 
     always @(negedge bus_write) begin
         wrdata_r <= extbus_d;
+        wraddr_r <= wraddr_hold_r;
     end
     always @(posedge bus_write) begin
-        wraddr_r <= extbus_a;
+        wraddr_hold_r <= extbus_a;
     end
     always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;


### PR DESCRIPTION
Back to back writes at 8MHz, which are possible with a 65C816 performing a 16-bit write to DATA0, were failing to get written to VRAM correctly because `wraddr_r` could get updated before the actual write to VRAM takes place. This change caches the bus address does not update `wraddr_r` until the falling edge of `bus_write` where the bus data is also captured.