### PR TITLE
R47 p1

### DIFF
--- a/fpga/source/audio/psg.v
+++ b/fpga/source/audio/psg.v
@@ -160,8 +160,8 @@ module psg(
     // Signal generation
     //////////////////////////////////////////////////////////////////////////
     wire [5:0] signal_pw       = (cur_phase[16:10] > {1'b0, cur_pulsewidth}) ? 6'd0 : 6'd63;
-    wire [5:0] signal_saw      = cur_phase[16:11];
-    wire [5:0] signal_triangle = cur_phase[16] ? ~cur_phase[15:10] : cur_phase[15:10];
+    wire [5:0] signal_saw      = cur_phase[16:11] ^ ~cur_pulsewidth[5:0];
+    wire [5:0] signal_triangle = (cur_phase[16] ? ~cur_phase[15:10] : cur_phase[15:10]) ^ ~cur_pulsewidth[5:0];
     wire [5:0] signal_noise    = cur_noise;
 
     reg [5:0] signal;

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -239,13 +239,15 @@ module top(
     // Capture address / write-data at end of write cycle
     reg [4:0] rdaddr_r;
     reg [4:0] wraddr_r;
+    reg [4:0] wraddr_hold_r;
     reg [7:0] wrdata_r;
 
     always @(negedge bus_write) begin
         wrdata_r <= extbus_d;
+        wraddr_r <= wraddr_hold_r;
     end
     always @(posedge bus_write) begin
-        wraddr_r <= extbus_a;
+        wraddr_hold_r <= extbus_a;
     end
     always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -188,7 +188,7 @@ module top(
             case(dc_select_r)
                 6'h0: rddata = dc_hscale_r;
                 6'h1: rddata = dc_active_hstop_r[9:2];
-                default: rddata = 8'h00;
+                default: rddata = 8'd0;
             endcase
         end
         5'h0B: begin
@@ -196,7 +196,7 @@ module top(
                 6'h0: rddata = dc_vscale_r;
                 6'h1: rddata = dc_active_vstart_r[8:1];
                 6'h5: rddata = fx_fill_length_low;
-                default: rddata = 8'h03;
+                default: rddata = 8'd47;
             endcase
         end
         5'h0C: begin
@@ -204,7 +204,7 @@ module top(
                 6'h0: rddata = dc_border_color_r;
                 6'h1: rddata = dc_active_vstop_r[8:1];
                 6'h5: rddata = fx_fill_length_high;
-                default: rddata = 8'h03;
+                default: rddata = 8'd0;
             endcase
         end
 

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -1,4 +1,7 @@
 //`default_nettype none
+`define VERSION_MAJOR 8'd47
+`define VERSION_MINOR 8'd1
+`define VERSION_BUILD 8'd1
 
 module top(
     input  wire       clk25,
@@ -239,15 +242,13 @@ module top(
     // Capture address / write-data at end of write cycle
     reg [4:0] rdaddr_r;
     reg [4:0] wraddr_r;
-    reg [4:0] wraddr_hold_r;
     reg [7:0] wrdata_r;
 
     always @(negedge bus_write) begin
         wrdata_r <= extbus_d;
-        wraddr_r <= wraddr_hold_r;
     end
     always @(posedge bus_write) begin
-        wraddr_hold_r <= extbus_a;
+        wraddr_r <= extbus_a;
     end
     always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -188,7 +188,7 @@ module top(
             case(dc_select_r)
                 6'h0: rddata = dc_hscale_r;
                 6'h1: rddata = dc_active_hstop_r[9:2];
-                default: rddata = 8'd0;
+                default: rddata = 8'd47;
             endcase
         end
         5'h0B: begin
@@ -196,7 +196,7 @@ module top(
                 6'h0: rddata = dc_vscale_r;
                 6'h1: rddata = dc_active_vstart_r[8:1];
                 6'h5: rddata = fx_fill_length_low;
-                default: rddata = 8'd47;
+                default: rddata = 8'd0;
             endcase
         end
         5'h0C: begin

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -191,7 +191,7 @@ module top(
             case(dc_select_r)
                 6'h0: rddata = dc_hscale_r;
                 6'h1: rddata = dc_active_hstop_r[9:2];
-                default: rddata = 8'd47;
+                default: rddata = `VERSION_MAJOR;
             endcase
         end
         5'h0B: begin
@@ -199,7 +199,7 @@ module top(
                 6'h0: rddata = dc_vscale_r;
                 6'h1: rddata = dc_active_vstart_r[8:1];
                 6'h5: rddata = fx_fill_length_low;
-                default: rddata = 8'd0;
+                default: rddata = `VERSION_MINOR;
             endcase
         end
         5'h0C: begin
@@ -207,7 +207,7 @@ module top(
                 6'h0: rddata = dc_border_color_r;
                 6'h1: rddata = dc_active_vstop_r[8:1];
                 6'h5: rddata = fx_fill_length_high;
-                default: rddata = 8'd0;
+                default: rddata = `VERSION_BUILD;
             endcase
         end
 

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -1,6 +1,6 @@
 //`default_nettype none
-`define VERSION_MAJOR 8'd47
-`define VERSION_MINOR 8'd1
+`define VERSION_MAJOR 8'd48
+`define VERSION_MINOR 8'd0
 `define VERSION_BUILD 8'd1
 
 module top(


### PR DESCRIPTION
Bump version to 48.0.1
Move version number to top of top.v file
Improve 65C02 stability
XOR Sawtooth and Triangle with width (#26)